### PR TITLE
Improved evaluation for open files. Respects semi-open files now and …

### DIFF
--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -136,7 +136,7 @@ class transposition;
 class repetition;
 class uci;
 class chessposition;
-
+struct pawnhashentry;
 
 //
 // utils stuff
@@ -530,6 +530,8 @@ const int roth1a8shift[64] = {
 
 extern U64 diaga1h8_attacks[64][64];
 extern U64 diagh1a8_attacks[64][64];
+extern U64 rank_attacks[64][64];
+extern U64 file_attacks[64][64];
 
 #endif //ROTATEDBITBOARD
 
@@ -605,7 +607,7 @@ public:
     void simpleUnplay(int from, int to, PieceCode capture);
     void getpvline(int depth, int pvnum);
     int getPositionValue();
-    int getPawnValue();
+    int getPawnValue(pawnhashentry **entry);
     int getValue();
 #ifdef DEBUG
     void debug(int depth, const char* format, ...);
@@ -840,6 +842,7 @@ typedef struct pawnhashentry {
     U64 passedpawnbb[2];
     U64 isolatedpawnbb[2];
     U64 backwardpawnbb[2];
+    int semiopen[2]; 
     short value;
 } S_PAWNHASHENTRY;
 

--- a/RubiChess/main.cpp
+++ b/RubiChess/main.cpp
@@ -666,17 +666,14 @@ long long perft(int depth, bool dotests)
             pos.print();
 //            printf("Material value: %d\n", pos.countMaterial());
             printf("Position value: %d\n", pos.getPositionValue());
-            printf("Pawn value: %d\n", pos.getPawnValue());
             pos.mirror();
             pos.print();
 //            printf("Material value: %d\n", pos.countMaterial());
             printf("Position value: %d\n", pos.getPositionValue());
-            printf("Pawn value: %d\n", pos.getPawnValue());
             pos.mirror();
             pos.print();
 //            printf("Material value: %d\n", pos.countMaterial());
             printf("Position value: %d\n", pos.getPositionValue());
-            printf("Pawn value: %d\n", pos.getPawnValue());
         }
     }
     chessmovelist* movelist = pos.getMoves();


### PR DESCRIPTION
…excludes queens.

Fixes for rotating bitboard compilation.

Finally an evaluation change with a very good score (LTC):
Score of RubiChess-Bitboard-sof vs RubiChess-Bitboard-Master: 290 - 193 - 317  [0.561] 800
Elo difference: 42.33 +/- 18.75
SPRT: llr 2.2, lbound -2.2, ubound 2.2 - H1 was accepted