### PR TITLE
Increase effectivedepth instead of descreasing it when search with re…

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -300,8 +300,8 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
                     if (reduction && score > alpha)
                     {
                         // research without reduction
-                        score = -alphabeta(-beta, -alpha, depth + extendall - 1, true);
-                        effectiveDepth--;
+						effectiveDepth += reduction;
+						score = -alphabeta(-beta, -alpha, effectiveDepth - 1, true);
                     }
                 }
                 else {


### PR DESCRIPTION
…duction fails. This writes position with bigger (and correct) depth to the tp.

This way is correct and even seems to gain a few ELO:

Score of RubiChess-Bitboard-rdfix vs RubiChess-Bitboard-ms: 1385 - 1324 - 1291  [0.508] 4000
Elo difference: 5.30 +/- 8.85
SPRT: llr 1.23, lbound -2.2, ubound 2.2