### PR TITLE
Nmporder and improved LMR

### DIFF
--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -265,6 +265,7 @@ const int lva[] = { 5 << 25, 4 << 25, 3 << 25, 3 << 25, 2 << 25, 1 << 25, 0 << 2
 #define PVVAL (7 << 28)
 #define KILLERVAL1 (1 << 27)
 #define KILLERVAL2 (KILLERVAL1 - 1)
+#define NMREFUTEVAL (1 << 26)
 #define TBFILTER INT32_MIN
 
 #ifdef BITBOARD

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -933,6 +933,7 @@ int rootsearch(int alpha, int beta, int depth);
 int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed);
 int getQuiescence(int alpha, int beta, int depth);
 void searchguide();
+void searchinit();
 
 
 //

--- a/RubiChess/main.cpp
+++ b/RubiChess/main.cpp
@@ -884,6 +884,7 @@ int main(int argc, char* argv[])
 #endif
 
     pos.init();
+	searchinit();
 
     cout.setf(ios_base::unitbuf);
 

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -10,7 +10,7 @@ void searchinit()
 {
 	for (int d = 0; d < MAXDEPTH; d++)
 		for (int m = 0; m < 64; m++)
-			reductiontable[d][m] = (int)round(log(d) * log(m) / 2.0);
+			reductiontable[d][m] = (int)round(log(d) * log(m) / 1.9);
 }
 
 

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -4,6 +4,16 @@
 
 const int deltapruningmargin = 200;
 
+int reductiontable[MAXDEPTH][64];
+
+void searchinit()
+{
+	for (int d = 0; d < MAXDEPTH; d++)
+		for (int m = 0; m < 64; m++)
+			reductiontable[d][m] = (int)round(log(d) * log(m) / 2.0);
+}
+
+
 int getQuiescence(int alpha, int beta, int depth)
 {
     int patscore, score;
@@ -99,7 +109,6 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
 {
     int score;
     uint32_t hashmovecode = 0;
-    int  LegalMoves = 0;
     bool isLegal;
     int bestscore = NOSCORE;
     uint32_t bestcode = 0;
@@ -258,11 +267,12 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
         }
         else if (!ISCAPTURE(m->code) && GETFROM(m->code) == nmrefutetarget)
         {
-            m->value += NMREFUTEVAL;
+            m->value |= NMREFUTEVAL;
         }
     }
 
-    for (int i = 0; i < newmoves->length; i++)
+	int  LegalMoves = 0;
+	for (int i = 0; i < newmoves->length; i++)
     {
         for (int j = i + 1; j < newmoves->length; j++)
         {
@@ -294,8 +304,11 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
             {
                 //extendall = 0; //FIXME: Indroduce extend variable for move specific extension
                 reduction = 0;
-                if (!extendall && depth > 2 && LegalMoves > 3 && !ISTACTICAL(m->code) && !pos.isCheck)
-                    reduction = 1;
+				// Late move reduction
+				if (!extendall && depth > 2 && !ISTACTICAL(m->code) && !pos.isCheck)
+				{
+					reduction = reductiontable[depth][min(63, LegalMoves)];
+				}
 #if 0
                 // disabled; capture extension doesn't seem to work
                 else if (ISTACTICAL(m->code) && GETPIECE(m->code) <= GETCAPTURE(m->code))

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -109,6 +109,7 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
     int extendall = 0;
     int reduction;
     int effectiveDepth;
+    int nmrefutetarget = -1;
 
     en.nodes++;
 
@@ -199,6 +200,14 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
                 extendall++;
             }
 #endif
+            int dummyscore;
+            uint32_t nmrefutemove = 0;
+            tp.probeHash(&dummyscore, &nmrefutemove, MAXDEPTH, 0, 0);
+            if (ISCAPTURE(nmrefutemove))
+            {
+                nmrefutetarget = GETTO(nmrefutemove);
+            }
+
             pos.unplayNullMove();
         }
     }
@@ -246,6 +255,10 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
         else if (pos.killer[1][0] == m->code)
         {
             m->value = KILLERVAL2;
+        }
+        else if (!ISCAPTURE(m->code) && GETFROM(m->code) == nmrefutetarget)
+        {
+            m->value += NMREFUTEVAL;
         }
     }
 

--- a/Tests/_temp/lmr.txt
+++ b/Tests/_temp/lmr.txt
@@ -1,0 +1,13 @@
+lmr3 (log-Reduction / 1.95)
+10+0.1:
+Score of RubiChess-Bitboard-lmr3 vs RubiChess-Bitboard-ms: 460 - 347 - 376  [0.548] 1183
+Elo difference: 33.29 +/- 16.38
+SPRT: llr 2.22, lbound -2.2, ubound 2.2 - H1 was accepted
+
+60+0.6:
+Score of RubiChess-Bitboard-lmr3 vs RubiChess-Bitboard-ms: 395 - 297 - 487  [0.542] 1179
+Elo difference: 28.95 +/- 15.20
+SPRT: llr 2.21, lbound -2.2, ubound 2.2 - H1 was accepted
+
+Regression test with  / 2.0:
+...

--- a/Tests/_temp/lmr.txt
+++ b/Tests/_temp/lmr.txt
@@ -9,5 +9,16 @@ Score of RubiChess-Bitboard-lmr3 vs RubiChess-Bitboard-ms: 395 - 297 - 487  [0.5
 Elo difference: 28.95 +/- 15.20
 SPRT: llr 2.21, lbound -2.2, ubound 2.2 - H1 was accepted
 
-Regression test with  / 2.0:
-...
+
+Regression test with ... / 2.0: (lmr4)
+Score of RubiChess-Bitboard-lmr4 vs RubiChess-Bitboard-lmr3: 401 - 438 - 461  [0.486] 1300
+Elo difference: -9.89 +/- 15.16
+SPRT: llr -0.594, lbound -2.2, ubound 2.2
+-> probably regression
+
+Regression test with ... / 1.9: (lmr5)
+Score of RubiChess-Bitboard-lmr5 vs RubiChess-Bitboard-lmr3: 3495 - 3486 - 4019  [0.500] 11000
+Elo difference: 0.28 +/- 5.17
+SPRT: llr 0.738, lbound -2.2, ubound 2.2
+
+


### PR DESCRIPTION
10+0.1:
Score of RubiChess-Bitboard-lmr3 vs RubiChess-Bitboard-ms: 460 - 347 - 376  [0.548] 1183
Elo difference: 33.29 +/- 16.38
SPRT: llr 2.22, lbound -2.2, ubound 2.2 - H1 was accepted

60+0.6:
Score of RubiChess-Bitboard-lmr3 vs RubiChess-Bitboard-ms: 395 - 297 - 487  [0.542] 1179
Elo difference: 28.95 +/- 15.20
SPRT: llr 2.21, lbound -2.2, ubound 2.2 - H1 was accepted
