### PR TITLE
No patscore when in check. Finally fixed and a pretty good improvemen…

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -17,7 +17,7 @@ void searchinit()
 int getQuiescence(int alpha, int beta, int depth)
 {
     int patscore, score;
-    int bestscore;
+    int bestscore = SHRT_MIN;
     bool isLegal;
     bool LegalMovesPossible = false;
 
@@ -28,10 +28,10 @@ int getQuiescence(int alpha, int beta, int depth)
 #endif
 
 
-    patscore = (pos.state & S2MMASK ? -pos.getValue() : pos.getValue());
-    bestscore = patscore;
     if (!pos.isCheck)
     {
+        patscore = (pos.state & S2MMASK ? -pos.getValue() : pos.getValue());
+        bestscore = patscore;
         PDEBUG(depth, "(getQuiscence) qnode=%d alpha=%d beta=%d patscore=%d\n", en.qnodes, alpha, beta, patscore);
         if (patscore >= beta)
             return patscore;
@@ -44,12 +44,11 @@ int getQuiescence(int alpha, int beta, int depth)
 
     for (int i = 0; i < movelist->length; i++)
     {
-        bool noDeltaprune = (patscore + materialvalue[GETCAPTURE(movelist->move[i].code) >> 1] + deltapruningmargin > alpha);
         PDEBUG(depth, "(getQuiscence) testing move %s ... LegalMovesPossible=%d Capture=%d Promotion=%d see=%d \n", movelist->move[i].toString().c_str(), (LegalMovesPossible?1:0), GETCAPTURE(movelist->move[i].code), GETPROMOTION(movelist->move[i].code), pos.see(GETFROM(movelist->move[i].code), GETTO(movelist->move[i].code)));
-        bool MoveIsUsefull = ((pos.isCheck && noDeltaprune)
+        bool MoveIsUsefull = (pos.isCheck
             || ISPROMOTION(movelist->move[i].code)
             || (ISCAPTURE(movelist->move[i].code) 
-                && noDeltaprune
+                && (patscore + materialvalue[GETCAPTURE(movelist->move[i].code) >> 1] + deltapruningmargin > alpha)
                 && (pos.see(GETFROM(movelist->move[i].code), GETTO(movelist->move[i].code)) >= 0)
             ));
 #ifdef DEBUG


### PR DESCRIPTION
…t, at least in STC selfplay:

Score of RubiChess-Bitboard-qs1 vs RubiChess-Bitboard-ms: 109 - 48 - 90  [0.623] 247
Elo difference: 87.62 +/- 35.07
SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted