### PR TITLE
Aspirationwindow

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -696,8 +696,8 @@ static void search_gen1()
     int score;
     int matein;
     int alpha, beta;
-    int deltaalpha = 25;
-    int deltabeta = 25;
+    int deltaalpha = 8;
+    int deltabeta = 8;
     int depth, maxdepth, depthincrement;
     string pvstring;
     int inWindow;
@@ -771,7 +771,7 @@ static void search_gen1()
                 // research with lower alpha and reduced beta
                 beta = (alpha + beta) / 2;
                 alpha = max(SHRT_MIN + 1, alpha - deltaalpha);
-                deltaalpha += deltaalpha / 4 + 12;
+                deltaalpha += deltaalpha / 4 + 2;
                 //deltaalpha <<= 1;
                 if (alpha < -1000)
                     deltaalpha = SHRT_MAX << 1;
@@ -784,7 +784,7 @@ static void search_gen1()
             {
                 // research with higher beta
                 beta = min(SHRT_MAX, beta + deltabeta);
-                deltabeta += deltabeta / 4 + 12;
+                deltabeta += deltabeta / 4 + 2;
                 //deltabeta <<= 1;
                 if (beta > 1000)
                     deltabeta = SHRT_MAX << 1;
@@ -802,8 +802,8 @@ static void search_gen1()
                 }
                 else {
                     // next depth with new aspiration window
-                    deltaalpha = 18;
-                    deltabeta = 18;
+                    deltaalpha = 8;
+                    deltabeta = 8;
                     //printf("info string depth=%d delta=%d\n", depth, deltaalpha);
                     if (isMultiPV)
                         alpha = pos.bestmovescore[en.MultiPV - 1] - deltaalpha;

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -768,9 +768,11 @@ static void search_gen1()
             // new aspiration window
             if (score == alpha)
             {
-                // research with lower alpha
+                // research with lower alpha and reduced beta
+                beta = (alpha + beta) / 2;
                 alpha = max(SHRT_MIN + 1, alpha - deltaalpha);
-                deltaalpha <<= 1;
+                deltaalpha += deltaalpha / 4 + 12;
+                //deltaalpha <<= 1;
                 if (alpha < -1000)
                     deltaalpha = SHRT_MAX << 1;
                 inWindow = 0;
@@ -782,7 +784,8 @@ static void search_gen1()
             {
                 // research with higher beta
                 beta = min(SHRT_MAX, beta + deltabeta);
-                deltabeta <<= 1;
+                deltabeta += deltabeta / 4 + 12;
+                //deltabeta <<= 1;
                 if (beta > 1000)
                     deltabeta = SHRT_MAX << 1;
                 inWindow = 2;
@@ -799,8 +802,9 @@ static void search_gen1()
                 }
                 else {
                     // next depth with new aspiration window
-                    deltaalpha = 25;
-                    deltabeta = 25;
+                    deltaalpha = 18;
+                    deltabeta = 18;
+                    //printf("info string depth=%d delta=%d\n", depth, deltaalpha);
                     if (isMultiPV)
                         alpha = pos.bestmovescore[en.MultiPV - 1] - deltaalpha;
                     else

--- a/Tests/_temp/aw.txt
+++ b/Tests/_temp/aw.txt
@@ -4,5 +4,20 @@ Score of RubiChess-Bitboard-aw1 vs RubiChess-Bitboard-ms: 976 - 895 - 1199  [0.5
 Elo difference: 9.17 +/- 9.58
 SPRT: llr 1.39, lbound -1.39, ubound 1.39 - H1 was accepted
 LTC:
+Score of RubiChess-Bitboard-aw1 vs RubiChess-Bitboard-ms: 395 - 366 - 639  [0.510] 1400
+Elo difference: 7.20 +/- 13.41
+SPRT: llr 0.501, lbound -1.39, ubound 1.39
 
 aw2: delta / 4 + 12
+Score of RubiChess-Bitboard-aw2 vs RubiChess-Bitboard-aw1: 290 - 316 - 394  [0.487] 1000
+Elo difference: -9.04 +/- 16.75
+SPRT: llr -0.604, lbound -1.39, ubound 1.39
+
+
+aw3: delta = 8; delta / 4 + 2
+STC against aw1:
+Score of RubiChess-Bitboard-aw3 vs RubiChess-Bitboard-aw1: 595 - 510 - 645  [0.524] 1750
+Elo difference: 16.89 +/- 12.93
+SPRT: llr 1.37, lbound -1.39, ubound 1.39
+LTC against master:
+...

--- a/Tests/_temp/aw.txt
+++ b/Tests/_temp/aw.txt
@@ -1,0 +1,8 @@
+aw1: delta = 18; delta +=delta / 4 + 5
+STC:
+Score of RubiChess-Bitboard-aw1 vs RubiChess-Bitboard-ms: 976 - 895 - 1199  [0.513] 3070
+Elo difference: 9.17 +/- 9.58
+SPRT: llr 1.39, lbound -1.39, ubound 1.39 - H1 was accepted
+LTC:
+
+aw2: delta / 4 + 12

--- a/Tests/_temp/aw.txt
+++ b/Tests/_temp/aw.txt
@@ -20,4 +20,6 @@ Score of RubiChess-Bitboard-aw3 vs RubiChess-Bitboard-aw1: 595 - 510 - 645  [0.5
 Elo difference: 16.89 +/- 12.93
 SPRT: llr 1.37, lbound -1.39, ubound 1.39
 LTC against master:
-...
+Score of RubiChess-Bitboard-aw3 vs RubiChess-Bitboard-ms: 161 - 96 - 236  [0.566] 493
+Elo difference: 46.08 +/- 22.16
+SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted


### PR DESCRIPTION
STC against aw1:
Score of RubiChess-Bitboard-aw3 vs RubiChess-Bitboard-aw1: 595 - 510 - 645  [0.524] 1750
Elo difference: 16.89 +/- 12.93
SPRT: llr 1.37, lbound -1.39, ubound 1.39
LTC against master:
Score of RubiChess-Bitboard-aw3 vs RubiChess-Bitboard-ms: 161 - 96 - 236  [0.566] 493
Elo difference: 46.08 +/- 22.16
SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted

