### PR TITLE
Sort moves in QSearch.

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -13,6 +13,17 @@ void searchinit()
             reductiontable[d][m] = (int)round(log(d) * log(m) / 1.9);
 }
 
+static void sortMoves(chessmovelist* movelist, int limit)
+{
+    for (int i = 0; i < movelist->length - 1; i++)
+    {
+        for (int j = i + 1; j < movelist->length; j++)
+            if (movelist->move[i].value < movelist->move[j].value)
+                swap(movelist->move[i], movelist->move[j]);
+        if (movelist->move[i].value < limit)
+            break;
+    }
+}
 
 int getQuiescence(int alpha, int beta, int depth)
 {
@@ -40,7 +51,7 @@ int getQuiescence(int alpha, int beta, int depth)
     }
 
     chessmovelist* movelist = pos.getMoves();
-    //pos->sortMoves(movelist);
+    sortMoves(movelist, lva[QUEEN]);
 
     for (int i = 0; i < movelist->length; i++)
     {


### PR DESCRIPTION
STC:
Score of RubiChess-Bitboard-sort1 vs RubiChess-Bitboard-MS: 638 - 551 - 717  [0.523] 1906
Elo difference: 15.87 +/- 12.31
SPRT: llr 1.41, lbound -1.39, ubound 1.39 - H1 was accepted

LTC:
Score of RubiChess-Bitboard-sort1 vs RubiChess-Bitboard-MS: 1379 - 1286 - 2413  [0.509] 5078
Elo difference: 6.36 +/- 6.91
SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted
