### PR TITLE
Fixes: Use killer move with correct ply index and raise history value…

### DIFF
--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -450,7 +450,7 @@ public:
     chessmove bestmove[MAXMULTIPV];
     int bestmovescore[MAXMULTIPV];
     unsigned long killer[2][MAXDEPTH];
-    unsigned int history[14][64];
+    unsigned int history[7][64];
 #ifdef DEBUG    
     unsigned long long debughash = 0;
 #endif

--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -320,7 +320,7 @@ int chessposition::getFromFen(const char* sFen)
     materialhash = zb.getMaterialHash();
     rp.clean();
     rp.addPosition(hash);
-    for (int i = 0; i < 14; i++)
+    for (int i = 0; i < 7; i++)
     {
         for (int j = 0; j < BOARDSIZE; j++)
         {

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -265,11 +265,11 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
             m->value = PVVAL;
         }
         // killermoves gets score better than non-capture
-        else if (pos.killer[0][0] == m->code)
+        else if (pos.killer[0][pos.ply] == m->code)
         {
             m->value = KILLERVAL1;
         }
-        else if (pos.killer[1][0] == m->code)
+        else if (pos.killer[1][pos.ply] == m->code)
         {
             m->value = KILLERVAL2;
         }
@@ -392,10 +392,14 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
                 if (score >= beta)
                 {
                     // Killermove
-                    if (GETCAPTURE(m->code) == BLANK)
+                    if (!ISCAPTURE(m->code))
                     {
-                        pos.killer[1][pos.ply] = pos.killer[0][pos.ply];
-                        pos.killer[0][pos.ply] = m->code;
+                        pos.history[pos.Piece(GETFROM(m->code))][GETTO(m->code)] += depth * depth;
+                        if (pos.killer[0][pos.ply] != m->code)
+                        {
+                            pos.killer[1][pos.ply] = pos.killer[0][pos.ply];
+                            pos.killer[0][pos.ply] = m->code;
+                        }
                     }
 
 #ifdef DEBUG
@@ -414,10 +418,6 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
                     PDEBUG(depth, "(alphabeta) score=%d > alpha=%d  -> new best move(%d) %s   Path:%s\n", score, alpha, depth, newmoves->move[i].toString().c_str(), pos.actualpath.toString().c_str());
                     alpha = score;
                     eval_type = HASHEXACT;
-                    if (!ISCAPTURE(m->code))
-                    {
-                        pos.history[pos.Piece(GETFROM(m->code))][GETTO(m->code)] += depth * depth;
-                    }
                 }
             }
         }
@@ -519,11 +519,11 @@ int rootsearch(int alpha, int beta, int depth)
                 m->value = PVVAL;
             }
             // killermoves gets score better than non-capture
-            else if (pos.killer[0][pos.ply] == m->code)
+            else if (pos.killer[0][0] == m->code)
             {
                 m->value = KILLERVAL1;
             }
-            else if (pos.killer[1][pos.ply] == m->code)
+            else if (pos.killer[1][0] == m->code)
             {
                 m->value = KILLERVAL2;
             }
@@ -635,10 +635,14 @@ int rootsearch(int alpha, int beta, int depth)
             if (score >= beta)
             {
                 // Killermove
-                if (GETCAPTURE(m->code) == BLANK)
+                if (!ISCAPTURE(m->code))
                 {
-                    pos.killer[1][0] = pos.killer[0][0];
-                    pos.killer[0][0] = m->code;
+                    pos.history[pos.Piece(GETFROM(m->code))][GETTO(m->code)] += depth * depth;
+                    if (pos.killer[0][0] != m->code)
+                    {
+                        pos.killer[1][0] = pos.killer[0][0];
+                        pos.killer[0][0] = m->code;
+                    }
                 }
 #ifdef DEBUG
                 en.fh++;
@@ -663,10 +667,6 @@ int rootsearch(int alpha, int beta, int depth)
                     alpha = score;
                 }
                 eval_type = HASHEXACT;
-                if (!ISCAPTURE(m->code))
-                {
-                    pos.history[pos.Piece(GETFROM(m->code))][GETTO(m->code)] += depth * depth;
-                }
             }
         }
     }


### PR DESCRIPTION
… only at fail high, not when raising alpha.

Score of RubiChess-Bitboard-hi1 vs RubiChess-Bitboard-ms: 133 - 82 - 210  [0.560] 425
Elo difference: 41.89 +/- 23.50
SPRT: llr 1.39, lbound -1.39, ubound 1.39 - H1 was accepted
