### PR TITLE
Some wip: Don't count on tt if root is in EGTB. Full aspiration windo…

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -452,7 +452,7 @@ int rootsearch(int alpha, int beta, int depth)
 #endif
 
     PDEBUG(depth, "depth=%d alpha=%d beta=%d\n", depth, alpha, beta);
-    if (!isMultiPV && tp.probeHash(&score, &hashmovecode, depth, alpha, beta))
+    if (!isMultiPV && !pos.useRootmoveScore && tp.probeHash(&score, &hashmovecode, depth, alpha, beta))
     {
         if (rp.getPositionCount(pos.hash) <= 1)  //FIXME: This is a rough guess to avoid draw by repetition hidden by the TP table
             return score;
@@ -751,7 +751,7 @@ static void search_gen1()
                 alpha = max(SHRT_MIN + 1, alpha - deltaalpha);
                 deltaalpha += deltaalpha / 4 + 2;
                 //deltaalpha <<= 1;
-                if (alpha < -1000)
+                if (abs(alpha) > 1000)
                     deltaalpha = SHRT_MAX << 1;
                 inWindow = 0;
 #ifdef DEBUG
@@ -764,7 +764,7 @@ static void search_gen1()
                 beta = min(SHRT_MAX, beta + deltabeta);
                 deltabeta += deltabeta / 4 + 2;
                 //deltabeta <<= 1;
-                if (beta > 1000)
+                if (abs(beta) > 1000)
                     deltabeta = SHRT_MAX << 1;
                 inWindow = 2;
 #ifdef DEBUG


### PR DESCRIPTION
…w if score > 1000 in both directions.

Test looks good:
LTC:
Score of RubiChess-Bitboard-tb2 vs RubiChess-Bitboard-ms: 548 - 521 - 1282  [0.506] 2351
Elo difference: 3.99 +/- 9.46
SPRT: llr 0.855, lbound -1.39, ubound 1.39
