### PR TITLE
Qsearch

### DIFF
--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -99,6 +99,7 @@ void Sleep(long x);
 #define PROMOTERANK(x) (RANK(x) == 0 || RANK(x) == 7)
 #define PROMOTERANKBB 0xff000000000000ff
 #define RANK3(s) ((s) ? 0x0000ff0000000000 : 0x0000000000ff0000)
+#define RANK7(s) ((s) ? 0x000000000000ff00 : 0x00ff000000000000)
 #define FILEABB 0x0101010101010101
 #define FILEHBB 0x8080808080808080
 #define OUTERFILE(x) (FILE(x) == 0 || FILE(x) == 7)
@@ -524,6 +525,7 @@ public:
     bool isAttacked(int index);
     int getLeastValuablePieceIndex(int to, unsigned int bySide, PieceCode *piece);
     int see(int from, int to);
+    int getBestPossibleCapture();
     int getMoves(chessmove *m, MoveType t = ALL);
     void getRootMoves();
     void tbFilterRootMoves();

--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -1746,6 +1746,29 @@ int chessposition::see(int from, int to)
     return gain[0];
 }
 
+int chessposition::getBestPossibleCapture()
+{
+    int me = state & S2MMASK;
+    int you = me ^ S2MMASK;
+    int captureval = 0;
+
+    if (pos.piece00[WQUEEN | you])
+        captureval += materialvalue[QUEEN];
+    else if (pos.piece00[WROOK | you])
+        captureval += materialvalue[ROOK];
+    else if (pos.piece00[WKNIGHT | you] || pos.piece00[WBISHOP | you])
+        captureval += materialvalue[KNIGHT];
+    else if (pos.piece00[WPAWN | you])
+        captureval += materialvalue[PAWN];
+
+    // promotion
+    if (pos.piece00[WPAWN | me] & RANK7(me))
+        captureval += materialvalue[QUEEN] - materialvalue[PAWN];
+
+    return captureval;
+}
+
+
 
 MoveSelector::~MoveSelector()
 {

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -2,7 +2,7 @@
 #include "RubiChess.h"
 
 
-const int deltapruningmargin = 75;
+const int deltapruningmargin = 100;
 
 int reductiontable[MAXDEPTH][64];
 

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -36,6 +36,11 @@ int getQuiescence(int alpha, int beta, int depth)
             return patscore;
         if (patscore > alpha)
             alpha = patscore;
+
+        // Delta pruning
+        int bestCapture = pos.getBestPossibleCapture();
+        if (patscore + deltapruningmargin + bestCapture < alpha)
+            return patscore;
     }
 
     chessmovelist *movelist = new chessmovelist;

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -2,7 +2,7 @@
 #include "RubiChess.h"
 
 
-const int deltapruningmargin = 50;
+const int deltapruningmargin = 75;
 
 int reductiontable[MAXDEPTH][64];
 

--- a/Tests/_temp/delta.txt
+++ b/Tests/_temp/delta.txt
@@ -1,0 +1,24 @@
+qs1: deltapruning vor allen Zügen
+Version ist laut Arena schneller als Master, scheint aber im Test zu verlieren
+Folglich muss deltamargin schlecht sein
+
+qs2: deltamargin=100
+Score of RubiChess-Bitboard-qs2 vs RubiChess-Bitboard-ms: 1286 - 1198 - 1714  [0.510] 4198
+Elo difference: 7.28 +/- 8.07
+SPRT: llr 1.41, lbound -1.39, ubound 1.39 - H1 was accepted
+
+
+qs3: deltamargin=150
+Score of RubiChess-Bitboard-qs3 vs RubiChess-Bitboard-qs2: 1473 - 1513 - 2014  [0.496] 5000
+Elo difference: -2.78 +/- 7.43
+SPRT: llr -1.33, lbound -1.39, ubound 1.39
+
+qs4: deltamargin=75
+Score of RubiChess-Bitboard-qs4 vs RubiChess-Bitboard-qs2: 1500 - 1469 - 2031  [0.503] 5000
+Elo difference: 2.15 +/- 7.41
+SPRT: llr 0.043, lbound -1.39, ubound 1.39
+
+qs5: deltamargin=125
+Score of RubiChess-Bitboard-qs5 vs RubiChess-Bitboard-qs2: 1145 - 1192 - 1681  [0.494] 4018
+Elo difference: -4.06 +/- 8.18
+SPRT: llr -1.39, lbound -1.39, ubound 1.39 - H0 was accepted

--- a/Tests/_temp/delta.txt
+++ b/Tests/_temp/delta.txt
@@ -3,22 +3,33 @@ Version ist laut Arena schneller als Master, scheint aber im Test zu verlieren
 Folglich muss deltamargin schlecht sein
 
 qs2: deltamargin=100
+STC:
 Score of RubiChess-Bitboard-qs2 vs RubiChess-Bitboard-ms: 1286 - 1198 - 1714  [0.510] 4198
 Elo difference: 7.28 +/- 8.07
 SPRT: llr 1.41, lbound -1.39, ubound 1.39 - H1 was accepted
-
+LTC:
+Score of RubiChess-Bitboard-qs2 vs RubiChess-Bitboard-ms: 386 - 327 - 702  [0.521] 1415
+Elo difference: 14.50 +/- 12.84
+SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted
 
 qs3: deltamargin=150
+STC gegen bisherige beste Version:
 Score of RubiChess-Bitboard-qs3 vs RubiChess-Bitboard-qs2: 1473 - 1513 - 2014  [0.496] 5000
 Elo difference: -2.78 +/- 7.43
 SPRT: llr -1.33, lbound -1.39, ubound 1.39
 
 qs4: deltamargin=75
+STC gegen bisherige beste Version:
 Score of RubiChess-Bitboard-qs4 vs RubiChess-Bitboard-qs2: 1500 - 1469 - 2031  [0.503] 5000
 Elo difference: 2.15 +/- 7.41
 SPRT: llr 0.043, lbound -1.39, ubound 1.39
+LTC gegen Master (Abbruch nach 850 Spielen wegen enttäuschendem Ergebnis):
+Score of RubiChess-Bitboard-qs4 vs RubiChess-Bitboard-ms: 214 - 213 - 423  [0.501] 850
+Elo difference: 0.41 +/- 16.54
+SPRT: llr -0.147, lbound -1.39, ubound 1.39
 
 qs5: deltamargin=125
+STC gegen bisherige beste Version:
 Score of RubiChess-Bitboard-qs5 vs RubiChess-Bitboard-qs2: 1145 - 1192 - 1681  [0.494] 4018
 Elo difference: -4.06 +/- 8.18
 SPRT: llr -1.39, lbound -1.39, ubound 1.39 - H0 was accepted


### PR DESCRIPTION
Score of RubiChess-Bitboard-qs2 vs RubiChess-Bitboard-ms: 386 - 327 - 702  [0.521] 1415
Elo difference: 14.50 +/- 12.84
SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted