### PR TITLE
History

### DIFF
--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -675,7 +675,6 @@ public:
     bool applyMove(string s);
     void print();
     int phase();
-    PieceType Piece(int index);
     bool isAttacked(int index);
     U64 attackedByBB(int index, U64 occ);
     bool see(uint32_t move, int threshold);

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -637,7 +637,7 @@ public:
     chessmove bestmove[MAXMULTIPV];
     int bestmovescore[MAXMULTIPV];
     uint32_t killer[2][MAXDEPTH];
-    uint32_t history[7][64];
+    int32_t history[7][64];
 #ifdef SDEBUG
     unsigned long long debughash = 0;
     uint16_t pvdebug[MAXMOVESEQUENCELENGTH];

--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -206,12 +206,6 @@ bool chessposition::w2m()
 }
 
 
-PieceType chessposition::Piece(int index)
-{
-    return (PieceType)(mailbox[index] >> 1);
-}
-
-
 int chessposition::getFromFen(const char* sFen)
 {
     string s;
@@ -806,7 +800,7 @@ string chessposition::toFen()
         {
             char c = 0;
             index = INDEX(r, f);
-            switch (Piece(index))
+            switch (mailbox[index] >> 1)
             {
             case PAWN:
                 c = 'p';

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -449,11 +449,11 @@ int alphabeta(int alpha, int beta, int depth, bool nullmoveallowed)
                     // Killermove
                     if (!ISCAPTURE(m->code))
                     {
-                        pos.history[pos.Piece(GETFROM(m->code))][GETTO(m->code)] += depth * depth;
+                        pos.history[GETPIECE(m->code) >> 1][GETTO(m->code)] += depth * depth;
                         for (int i = 0; i < quietsPlayed; i++)
                         {
                             uint32_t qm = quietMoves[i];
-                            pos.history[pos.Piece(GETFROM(qm))][GETTO(qm)] -= depth * depth;
+                            pos.history[GETPIECE(qm) >> 1][GETTO(qm)] -= depth * depth;
                         }
 
                         if (pos.killer[0][pos.ply] != m->code)
@@ -703,11 +703,11 @@ int rootsearch(int alpha, int beta, int depth)
             // Killermove
             if (!ISCAPTURE(m->code))
             {
-                pos.history[pos.Piece(GETFROM(m->code))][GETTO(m->code)] += depth * depth;
+                pos.history[GETPIECE(m->code) >> 1][GETTO(m->code)] += depth * depth;
                 for (int i = 0; i < quietsPlayed - 1; i++)
                 {
                     uint32_t qm = quietMoves[i];
-                    pos.history[pos.Piece(GETFROM(qm))][GETTO(qm)] -= depth * depth;
+                    pos.history[GETPIECE(qm) >> 1][GETTO(qm)] -= depth * depth;
                 }
 
                 if (pos.killer[0][0] != m->code)
@@ -718,7 +718,6 @@ int rootsearch(int alpha, int beta, int depth)
             }
             SDEBUGPRINT(isDebugPv, debugInsert, " Beta-cutoff by move %s: %d", m->toString().c_str(), score);
             tp.addHash(pos.hash, beta, HASHBETA, effectiveDepth, (uint16_t)m->code);
-            //free(newmoves);
             return beta;   // fail hard beta-cutoff
         }
 


### PR DESCRIPTION
LTC:
Score of RubiChess-Bitboard-hi2 vs RubiChess-Bitboard-ms: 245 - 193 - 488  [0.528] 926
Elo difference: 19.53 +/- 15.38
SPRT: llr 1.39, lbound -1.39, ubound 1.39 - H1 was accepted
