### PR TITLE
Leave out captures with neutral see in quiescence search.

### DIFF
--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -2164,7 +2164,7 @@ chessmove* MoveSelector::next()
     case TACTICALSTATE:
         while (capturemovenum < captures->length
             && (captures->move[capturemovenum].code == hashmove.code
-                || !pos->see(captures->move[capturemovenum].code, 0)))
+                || !pos->see(captures->move[capturemovenum].code, onlyGoodCaptures)))
         {
             // mark the move for BADTACTICALSTATE
             captures->move[capturemovenum].value |= (1 << 31);


### PR DESCRIPTION
STC[0,5]:
Score of RubiChess-se1 vs RubiChess-ms: 552 - 484 - 787  [0.519] 1823
Elo difference: 12.97 +/- 12.01
SPRT: llr 1.39, lbound -1.39, ubound 1.39 - H1 was accepted
LTC[0,5]:
Score of RubiChess-se1 vs RubiChess-ms: 1487 - 1397 - 3357  [0.507] 6241
Elo difference: 5.01 +/- 5.85
SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted
