### PR TITLE
Don't set bestmovescore if hashvalue fails low.

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -606,7 +606,7 @@ int chessposition::rootsearch(int alpha, int beta, int depth)
         if (fullhashmove)
         {
             bestmove[0].code = fullhashmove;
-            bestmovescore[0] = score;
+            if (score > alpha) bestmovescore[0] = score;
             return score;
         }
     }


### PR DESCRIPTION
STC 1th:
Score of RubiChess-bm3 vs RubiChess-ms: 1290 - 1236 - 1983  [0.506] 4509
Elo difference: 4.16 +/- 7.58
SPRT: llr 1.38, lbound -1.39, ubound 1.39

STC 4th:
+297,=541,-240), 52.6 %
