### PR TITLE
Qsearchprune

### DIFF
--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -855,8 +855,8 @@ public:
 	string toString();
 	string toStringWithValue();
 	void print();
-    void sort(const unsigned int refutetarget = BOARDSIZE);
-    void sort(uint32_t hashmove, uint32_t killer1, uint32_t killer2);
+    void sort();
+    //void sort(uint32_t hashmove, uint32_t killer1, uint32_t killer2);
 };
 
 
@@ -881,7 +881,7 @@ public:
     int16_t *cmptr[CMPLIES];
 
 public:
-    void SetPreferredMoves(chessposition *p, uint16_t hshm);  // for quiescence move selector
+    void SetPreferredMoves(chessposition *p);  // for quiescence move selector
     void SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t kllm1, uint32_t kllm2, int nmrfttarget, int excludemove);
     chessmove* next();
 };

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -856,7 +856,6 @@ public:
 	string toStringWithValue();
 	void print();
     void sort();
-    //void sort(uint32_t hashmove, uint32_t killer1, uint32_t killer2);
 };
 
 
@@ -873,7 +872,6 @@ public:
     chessmove hashmove;
     chessmove killermove1;
     chessmove killermove2;
-    int refutetarget;
     int capturemovenum;
     int quietmovenum;
     int legalmovenum;
@@ -882,7 +880,7 @@ public:
 
 public:
     void SetPreferredMoves(chessposition *p);  // for quiescence move selector
-    void SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t kllm1, uint32_t kllm2, int nmrfttarget, int excludemove);
+    void SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t kllm1, uint32_t kllm2, int excludemove);
     chessmove* next();
 };
 

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -881,7 +881,7 @@ public:
     int16_t *cmptr[CMPLIES];
 
 public:
-    void SetPreferredMoves(chessposition *p);  // for quiescence move selector
+    void SetPreferredMoves(chessposition *p, uint16_t hshm);  // for quiescence move selector
     void SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t kllm1, uint32_t kllm2, int nmrfttarget, int excludemove);
     chessmove* next();
 };

--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -206,10 +206,12 @@ void chessmovelist::sort(uint32_t hashmove, uint32_t killer1, uint32_t killer2)
     {
         if (move[i].code == hashmove)
             move[i].value = PVVAL;
+#if 0
         else if (move[i].code == killer1)
             move[i].value = KILLERVAL1;
         else if (move[i].code == killer2)
             move[i].value = KILLERVAL2;
+#endif
     }
     for (int i = 0; i < length - 1; i++)
     {
@@ -2081,16 +2083,17 @@ int chessposition::getBestPossibleCapture()
 
 
 // MoveSelector for quiescence search
-void MoveSelector::SetPreferredMoves(chessposition *p)
+void MoveSelector::SetPreferredMoves(chessposition *p, uint16_t hshm)
 {
     pos = p;
-    hashmove.code = 0;
+    hashmove.code = p->shortMove2FullMove(hshm);
     killermove1.code = killermove2.code = 0;
     refutetarget = BOARDSIZE;
     if (!p->isCheckbb)
     {
         onlyGoodCaptures = true;
-        state = TACTICALINITSTATE;
+        if (!ISTACTICAL(hashmove.code))
+            state = TACTICALINITSTATE;
     }
     else
     {

--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -183,7 +183,7 @@ void chessmovelist::print()
     printf("%s", toString().c_str());
 }
 
-// Sorting for normal MoveSelector
+// Sorting for MoveSelector
 void chessmovelist::sort()
 {
     for (int i = 0; i < length - 1; i++)
@@ -194,29 +194,6 @@ void chessmovelist::sort()
     }
 }
 
-#if 0
-// Sorting for evasion MoveSelector; FIXME: preparing high values for hash and killermoves is ugly
-void chessmovelist::sort(uint32_t hashmove, uint32_t killer1, uint32_t killer2)
-{
-    for (int i = 0; i < length - 1; i++)
-    {
-        if (move[i].code == hashmove)
-            move[i].value = PVVAL;
-#if 0
-        else if (move[i].code == killer1)
-            move[i].value = KILLERVAL1;
-        else if (move[i].code == killer2)
-            move[i].value = KILLERVAL2;
-#endif
-    }
-    for (int i = 0; i < length - 1; i++)
-    {
-        for (int j = i + 1; j < length; j++)
-            if (move[i].value < move[j].value)
-                swap(move[i], move[j]);
-    }
-}
-#endif
 
 chessmovesequencelist::chessmovesequencelist()
 {
@@ -2084,7 +2061,6 @@ void MoveSelector::SetPreferredMoves(chessposition *p)
     pos = p;
     hashmove.code = 0;
     killermove1.code = killermove2.code = 0;
-    refutetarget = BOARDSIZE;
     if (!p->isCheckbb)
     {
         onlyGoodCaptures = true;
@@ -2101,7 +2077,7 @@ void MoveSelector::SetPreferredMoves(chessposition *p)
 }
 
 // MoveSelector for alphabeta search
-void MoveSelector::SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t kllm1, uint32_t kllm2, int nmrfttarget, int excludemove)
+void MoveSelector::SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t kllm1, uint32_t kllm2, int excludemove)
 {
     pos = p;
     hashmove.code = p->shortMove2FullMove(hshm);
@@ -2109,7 +2085,6 @@ void MoveSelector::SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t k
         killermove1.code = kllm1;
     if (kllm2 != hshm)
         killermove2.code = kllm2;
-    refutetarget = nmrfttarget;
     pos->getCmptr(&cmptr[0]);
     if (!excludemove)
     {

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -156,7 +156,7 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
             continue;
 
         if (myIsCheck && !ISTACTICAL(m->code)
-            && ( depth < 0 || ms.capturemovenum > 1)
+            && ( depth < 0 || ms.capturemovenum > 2)
             && bestscore > SCOREBLACKWINS
             && !see(m->code, 0))
             // Leave out check evasions that lose a piece

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -155,7 +155,7 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
     prepareStack();
 
     MoveSelector ms = {};
-    ms.SetPreferredMoves(this);
+    ms.SetPreferredMoves(this, hashmovecode);
 
     chessmove *m;
 

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -220,7 +220,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     chessmove *m;
     int extendall = 0;
     int effectiveDepth;
-    unsigned int nmrefutetarget = BOARDSIZE;
     bool PVNode = (alpha != beta - 1);
 
     nodes++;
@@ -441,7 +440,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     }
 
     MoveSelector ms = {};
-    ms.SetPreferredMoves(this, hashmovecode, killer[0][ply], killer[1][ply], nmrefutetarget, excludeMove);
+    ms.SetPreferredMoves(this, hashmovecode, killer[0][ply], killer[1][ply], excludeMove);
 
     int  LegalMoves = 0;
     int quietsPlayed = 0;

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -247,6 +247,18 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         return SCOREDRAW;
     }
 
+
+    // Reached depth? Do a qsearch
+    if (depth <= 0)
+    {
+        // update selective depth info
+        if (seldepth < ply + 1)
+            seldepth = ply + 1;
+
+        return getQuiescence(alpha, beta, depth);
+    }
+
+
     // Get move for singularity check and change hash to seperate partial searches from full searches
     uint16_t excludeMove = excludemovestack[mstop - 1];
     excludemovestack[mstop] = 0;
@@ -311,16 +323,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
             return score;
         }
-    }
-
-
-    if (depth <= 0)
-    {
-        // update selective depth info
-        if (seldepth < ply + 1)
-           seldepth = ply + 1;
-
-        return getQuiescence(alpha, beta, depth);
     }
 
     // Check extension

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -155,6 +155,13 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
             // Leave out capture that is delta-pruned
             continue;
 
+        if (myIsCheck && !ISTACTICAL(m->code)
+            && ( depth < 0 || ms.capturemovenum > 1)
+            && bestscore > SCOREBLACKWINS
+            && !see(m->code, 0))
+            // Leave out check evasions that lose a piece
+            continue;
+
         bool isLegal = playMove(m);
         if (isLegal)
         {

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -155,7 +155,7 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
     prepareStack();
 
     MoveSelector ms = {};
-    ms.SetPreferredMoves(this, hashmovecode);
+    ms.SetPreferredMoves(this);
 
     chessmove *m;
 


### PR DESCRIPTION
Score of RubiChess-qsp4b vs RubiChess-ms: 392 - 340 - 1085  [0.514] 1817
Elo difference: 9.95 +/- 10.13
SPRT: llr 1.39, lbound -1.39, ubound 1.39 - H1 was accepted
