### PR TITLE
kingpin evaluation

### DIFF
--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -250,7 +250,7 @@ typedef const int32_t eval;
 #define NUMOFEVALPARAMS (6 + 2*5*4 + 5 + 4*8 + 2*8 + 8 + 2 + 5*6 + 2 + 4*28 + 2 + 7 + 1 + 7 + 6 + 6 + 2 + 7*64)
 struct evalparamset {
     // Powered by Laser games :-)
-    eval eKingpinpenalty[6] = {  VALUE(   0,   0), VALUE(   0,   0), VALUE( -32, -92), VALUE(   1,-104), VALUE( -47, -43), VALUE( -44, -54)  };
+    eval eKingpinpenalty[6] = {  VALUE(   0,   0), VALUE(   0,   0), VALUE(  38, -74), VALUE(  65, -61), VALUE( -29,  68), VALUE( -44, 163)  };
     eval ePawnstormblocked[4][5] = {
         {  VALUE(   0,   0), VALUE(   0,   0), VALUE(  -6,  -4), VALUE(  26, -11), VALUE(  30, -11)  },
         {  VALUE(   0,   0), VALUE(   0,   0), VALUE(  -3, -13), VALUE(  24, -19), VALUE(   8,  -8)  },
@@ -291,22 +291,22 @@ struct evalparamset {
     eval eBackwardpawnpenalty =  VALUE( -10, -15);
     eval eDoublebishopbonus =  VALUE(  56,  38);
     eval eMobilitybonus[4][28] = {
-        {  VALUE(  14, -90), VALUE(  35, -26), VALUE(  49,  -3), VALUE(  55,  10), VALUE(  63,  20), VALUE(  69,  32), VALUE(  75,  32), VALUE(  82,  32),
-           VALUE(  84,  22), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
+        {  VALUE(  16, -90), VALUE(  38, -26), VALUE(  51,   1), VALUE(  57,  13), VALUE(  64,  27), VALUE(  71,  37), VALUE(  77,  36), VALUE(  84,  36),
+           VALUE(  86,  30), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0)  },
-        {  VALUE(  19, -32), VALUE(  32,  -8), VALUE(  50,  12), VALUE(  57,  19), VALUE(  67,  32), VALUE(  74,  33), VALUE(  79,  38), VALUE(  79,  46),
-           VALUE(  81,  47), VALUE(  81,  48), VALUE(  83,  45), VALUE(  81,  39), VALUE(  74,  51), VALUE(  70,  27), VALUE(   0,   0), VALUE(   0,   0),
+        {  VALUE(  21, -25), VALUE(  34,  -6), VALUE(  51,  13), VALUE(  59,  23), VALUE(  69,  34), VALUE(  75,  40), VALUE(  81,  43), VALUE(  81,  50),
+           VALUE(  84,  51), VALUE(  83,  55), VALUE(  85,  52), VALUE(  81,  47), VALUE(  72,  59), VALUE(  72,  31), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0)  },
-        {  VALUE( -60,  10), VALUE(  13,   0), VALUE(  30,  48), VALUE(  33,  63), VALUE(  35,  73), VALUE(  37,  82), VALUE(  39,  88), VALUE(  46,  89),
-           VALUE(  47,  92), VALUE(  49, 102), VALUE(  52, 103), VALUE(  48, 108), VALUE(  47, 109), VALUE(  48, 111), VALUE(  45, 110), VALUE(   0,   0),
+        {  VALUE( -57,  11), VALUE(  14,  17), VALUE(  31,  57), VALUE(  34,  70), VALUE(  36,  82), VALUE(  38,  90), VALUE(  40,  92), VALUE(  46,  96),
+           VALUE(  47, 101), VALUE(  50, 111), VALUE(  54, 109), VALUE(  50, 115), VALUE(  49, 118), VALUE(  50, 116), VALUE(  44, 116), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0)  },
-        {  VALUE(-4097,  83), VALUE(  12,-166), VALUE(  -3,  -5), VALUE(   3,  40), VALUE(   4,  80), VALUE(   3, 138), VALUE(   5, 154), VALUE(  10, 158),
-           VALUE(   9, 182), VALUE(  14, 170), VALUE(  13, 200), VALUE(  16, 203), VALUE(  16, 208), VALUE(  18, 217), VALUE(  16, 235), VALUE(  19, 238),
-           VALUE(  19, 239), VALUE(  21, 237), VALUE(  17, 243), VALUE(  10, 260), VALUE(  45, 232), VALUE(  67, 222), VALUE(  71, 224), VALUE(  84, 211),
-           VALUE(  69, 248), VALUE( 109, 216), VALUE( 106, 200), VALUE( 114, 189)  }
+        {  VALUE(-4097,  83), VALUE(  13,-157), VALUE(  -2,  31), VALUE(   3,  75), VALUE(   5,  94), VALUE(   4, 152), VALUE(   6, 161), VALUE(  11, 177),
+           VALUE(  10, 192), VALUE(  15, 187), VALUE(  14, 212), VALUE(  17, 213), VALUE(  16, 227), VALUE(  18, 229), VALUE(  17, 242), VALUE(  19, 251),
+           VALUE(  20, 253), VALUE(  21, 256), VALUE(  18, 263), VALUE(  13, 270), VALUE(  45, 244), VALUE(  67, 233), VALUE(  72, 241), VALUE(  80, 230),
+           VALUE(  69, 264), VALUE( 108, 231), VALUE( 107, 230), VALUE( 114, 198)  }
     };
     eval eSlideronfreefilebonus[2] = {  VALUE(  21,   7), VALUE(  43,   1)  };
     eval eMaterialvalue[7] = {  VALUE(   0,   0), VALUE( 100, 100), VALUE( 314, 314), VALUE( 314, 314), VALUE( 483, 483), VALUE( 913, 913), VALUE(32509,32509)  };

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -1011,6 +1011,7 @@ public:
     void unplayNullMove();
     bool moveGivesCheck(uint32_t c);  // simple and imperfect as it doesn't handle special moves and cases (mainly to avoid pruning of important moves)
     bool moveIsPseudoLegal(uint32_t c);     // test if move is possible in current position
+    bool moveIsLegal(uint32_t c);   // test if the move is legal means the moving side isn't checked after the move
     uint32_t shortMove2FullMove(uint16_t c); // transfer movecode from tt to full move code without checking if pseudoLegal
     template <EvalType Et> int getPositionValue();
     template <EvalType Et> int getPawnAndKingValue(pawnhashentry **entry);

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -247,9 +247,10 @@ typedef const int32_t eval;
 
 #define TAPEREDANDSCALEDEVAL(s, p, c) ((GETMGVAL(s) * (256 - (p)) + GETEGVAL(s) * (p) * (c) / SCALE_NORMAL) / 256)
 
-#define NUMOFEVALPARAMS (2*5*4 + 5 + 4*8 + 2*8 + 8 + 2 + 5*6 + 2 + 4*28 + 2 + 7 + 1 + 7 + 6 + 6 + 2 + 7*64)
+#define NUMOFEVALPARAMS (6 + 2*5*4 + 5 + 4*8 + 2*8 + 8 + 2 + 5*6 + 2 + 4*28 + 2 + 7 + 1 + 7 + 6 + 6 + 2 + 7*64)
 struct evalparamset {
     // Powered by Laser games :-)
+    eval eKingpinpenalty[6] = {  VALUE(   0,   0), VALUE(   0,   0), VALUE( -32, -92), VALUE(   1,-104), VALUE( -47, -43), VALUE( -44, -54)  };
     eval ePawnstormblocked[4][5] = {
         {  VALUE(   0,   0), VALUE(   0,   0), VALUE(  -6,  -4), VALUE(  26, -11), VALUE(  30, -11)  },
         {  VALUE(   0,   0), VALUE(   0,   0), VALUE(  -3, -13), VALUE(  24, -19), VALUE(   8,  -8)  },
@@ -290,22 +291,22 @@ struct evalparamset {
     eval eBackwardpawnpenalty =  VALUE( -10, -15);
     eval eDoublebishopbonus =  VALUE(  56,  38);
     eval eMobilitybonus[4][28] = {
-        {  VALUE(  15, -97), VALUE(  35, -30), VALUE(  48,  -9), VALUE(  54,   2), VALUE(  60,  15), VALUE(  67,  27), VALUE(  73,  27), VALUE(  80,  24),
-           VALUE(  83,  17), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
+        {  VALUE(  14, -90), VALUE(  35, -26), VALUE(  49,  -3), VALUE(  55,  10), VALUE(  63,  20), VALUE(  69,  32), VALUE(  75,  32), VALUE(  82,  32),
+           VALUE(  84,  22), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0)  },
-        {  VALUE(  19, -46), VALUE(  31, -19), VALUE(  48,   3), VALUE(  54,  13), VALUE(  66,  21), VALUE(  72,  27), VALUE(  77,  31), VALUE(  77,  37),
-           VALUE(  79,  39), VALUE(  79,  41), VALUE(  79,  38), VALUE(  79,  32), VALUE(  75,  42), VALUE(  75,  20), VALUE(   0,   0), VALUE(   0,   0),
+        {  VALUE(  19, -32), VALUE(  32,  -8), VALUE(  50,  12), VALUE(  57,  19), VALUE(  67,  32), VALUE(  74,  33), VALUE(  79,  38), VALUE(  79,  46),
+           VALUE(  81,  47), VALUE(  81,  48), VALUE(  83,  45), VALUE(  81,  39), VALUE(  74,  51), VALUE(  70,  27), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0)  },
-        {  VALUE( -60,  13), VALUE(  14,   5), VALUE(  30,  41), VALUE(  33,  54), VALUE(  34,  65), VALUE(  36,  70), VALUE(  38,  74), VALUE(  44,  75),
-           VALUE(  46,  82), VALUE(  48,  93), VALUE(  50,  92), VALUE(  48,  95), VALUE(  46, 100), VALUE(  48,  98), VALUE(  44,  98), VALUE(   0,   0),
+        {  VALUE( -60,  10), VALUE(  13,   0), VALUE(  30,  48), VALUE(  33,  63), VALUE(  35,  73), VALUE(  37,  82), VALUE(  39,  88), VALUE(  46,  89),
+           VALUE(  47,  92), VALUE(  49, 102), VALUE(  52, 103), VALUE(  48, 108), VALUE(  47, 109), VALUE(  48, 111), VALUE(  45, 110), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0),
            VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0)  },
-        {  VALUE(-4097,  83), VALUE(   7,-166), VALUE(  -3,  -7), VALUE(   1,  34), VALUE(   1,  58), VALUE(   0, 125), VALUE(   2, 134), VALUE(   7, 128),
-           VALUE(   7, 150), VALUE(  13, 141), VALUE(  14, 163), VALUE(  16, 166), VALUE(  17, 173), VALUE(  18, 189), VALUE(  15, 206), VALUE(  20, 206),
-           VALUE(  20, 217), VALUE(  22, 211), VALUE(  19, 218), VALUE(  14, 232), VALUE(  49, 201), VALUE(  71, 194), VALUE(  76, 198), VALUE(  83, 187),
-           VALUE(  72, 218), VALUE( 118, 187), VALUE( 102, 190), VALUE(  98, 190)  }
+        {  VALUE(-4097,  83), VALUE(  12,-166), VALUE(  -3,  -5), VALUE(   3,  40), VALUE(   4,  80), VALUE(   3, 138), VALUE(   5, 154), VALUE(  10, 158),
+           VALUE(   9, 182), VALUE(  14, 170), VALUE(  13, 200), VALUE(  16, 203), VALUE(  16, 208), VALUE(  18, 217), VALUE(  16, 235), VALUE(  19, 238),
+           VALUE(  19, 239), VALUE(  21, 237), VALUE(  17, 243), VALUE(  10, 260), VALUE(  45, 232), VALUE(  67, 222), VALUE(  71, 224), VALUE(  84, 211),
+           VALUE(  69, 248), VALUE( 109, 216), VALUE( 106, 200), VALUE( 114, 189)  }
     };
     eval eSlideronfreefilebonus[2] = {  VALUE(  21,   7), VALUE(  43,   1)  };
     eval eMaterialvalue[7] = {  VALUE(   0,   0), VALUE( 100, 100), VALUE( 314, 314), VALUE( 314, 314), VALUE( 483, 483), VALUE( 913, 913), VALUE(32509,32509)  };

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -118,6 +118,7 @@ void Sleep(long x);
 #define BUILD __DATE__ " " __TIME__
 
 #define BITSET(x) (1ULL << (x))
+#define ONEORZERO(x) (!((x) & ((x) - 1)))
 #ifdef _WIN32
 #define GETLSB(i,x) _BitScanForward64((DWORD*)&(i), (x))
 inline int pullLsb(unsigned long long *x) {
@@ -674,7 +675,7 @@ const int lva[] = { 5 << 24, 4 << 24, 3 << 24, 3 << 24, 2 << 24, 1 << 24, 0 << 2
 #define ISCAPTURE(x) ((x) & 0xf0000)
 #define GETPIECE(x) (((x) & 0xf0000000) >> 28)
 #define GETTACTICALVALUE(x) (materialvalue[GETCAPTURE(x) >> 1] + (ISPROMOTION(x) ? materialvalue[GETPROMOTION(x) >> 1] - materialvalue[PAWN] : 0))
-
+#define ISCASTLE(c) (((c) & 0xe0000249) == 0xc0000000)
 #define GIVECHECKFLAG 0x08000000
 #define GIVESCHECK(x) ((x) & GIVECHECKFLAG)
 
@@ -794,6 +795,8 @@ struct chessmovestack
     int halfmovescounter;
     int fullmovescounter;
     U64 isCheckbb;
+    U64 kingPinned[2];
+    U64 queenPinned[2];
     uint32_t movecode;
 };
 
@@ -933,6 +936,8 @@ public:
     int halfmovescounter;
     int fullmovescounter;
     U64 isCheckbb;
+    U64 kingPinned[2];
+    U64 queenPinned[2];
     uint32_t movecode;
 
     uint8_t mailbox[BOARDSIZE]; // redundand for faster "which piece is on field x"
@@ -1009,6 +1014,7 @@ public:
     void unplayMove(chessmove *cm);
     void playNullMove();
     void unplayNullMove();
+    void updatePins();
     bool moveGivesCheck(uint32_t c);  // simple and imperfect as it doesn't handle special moves and cases (mainly to avoid pruning of important moves)
     bool moveIsPseudoLegal(uint32_t c);     // test if move is possible in current position
     bool moveIsLegal(uint32_t c);   // test if the move is legal means the moving side isn't checked after the move

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -796,8 +796,6 @@ struct chessmovestack
     int halfmovescounter;
     int fullmovescounter;
     U64 isCheckbb;
-    U64 kingPinned[2];
-    U64 queenPinned[2];
     uint32_t movecode;
 };
 
@@ -926,6 +924,7 @@ public:
     U64 occupied00[2];
     U64 attackedBy2[2];
     U64 attackedBy[2][7];
+    U64 kingPinned[2];
 
     // The following block is mapped/copied to the movestack, so its important to keep the order
     int state;
@@ -937,8 +936,6 @@ public:
     int halfmovescounter;
     int fullmovescounter;
     U64 isCheckbb;
-    U64 kingPinned[2];
-    U64 queenPinned[2];
     uint32_t movecode;
 
     uint8_t mailbox[BOARDSIZE]; // redundand for faster "which piece is on field x"
@@ -1018,7 +1015,6 @@ public:
     void updatePins();
     bool moveGivesCheck(uint32_t c);  // simple and imperfect as it doesn't handle special moves and cases (mainly to avoid pruning of important moves)
     bool moveIsPseudoLegal(uint32_t c);     // test if move is possible in current position
-    bool moveIsLegal(uint32_t c);   // test if the move is legal means the moving side isn't checked after the move
     uint32_t shortMove2FullMove(uint16_t c); // transfer movecode from tt to full move code without checking if pseudoLegal
     template <EvalType Et> int getPositionValue();
     template <EvalType Et> int getPawnAndKingValue(pawnhashentry **entry);

--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -760,44 +760,6 @@ bool chessposition::moveIsPseudoLegal(uint32_t c)
 }
 
 
-bool chessposition::moveIsLegal(uint32_t c)
-{
-    int me = state & S2MMASK;
-    int you = me ^ S2MMASK;
-    int from = GETFROM(c);
-    int to = GETTO(c);
-
-    // castle moves are always legal; move generator checks for it
-    if (ISCASTLE(c))
-        return true;
-
-    if (GETEPCAPTURE(c))
-    {
-        int epfield = (from & 0x38) | (to & 0x07);
-        int pc = GETPIECE(c);
-        BitboardClear(epfield, pc ^ S2MMASK);
-        BitboardMove(from, to, pc);
-        bool legal = !isAttacked(kingpos[me]);
-        BitboardMove(to, from, pc);
-        BitboardSet(epfield, pc ^ S2MMASK);
-        if (!legal)
-            return false;
-    }
-
-    // Moving king: just check if target square is attacked
-    if ((GETPIECE(c) >> 1) == KING)
-        return !(isAttacked(to));
-
-    // Other pieces: Do they expose the king to an attacking piece?
-    if ((kingPinned[me] & BITSET(from))
-        && !(lineMask[from][to] & BITSET(kingpos[me])))
-        return false;
-
-
-    return true;
-}
-
-
 void chessposition::updatePins()
 {
     for (int me = WHITE; me <= BLACK; me++)
@@ -817,7 +779,6 @@ void chessposition::updatePins()
                 kingPinned[me] |= potentialPinners;
         }
     }
-
 }
 
 

--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -759,6 +759,30 @@ bool chessposition::moveIsPseudoLegal(uint32_t c)
 }
 
 
+bool chessposition::moveIsLegal(uint32_t c)
+{
+    int me = state & S2MMASK;
+    int you = me ^ S2MMASK;
+    int from = GETFROM(c);
+    int to = GETTO(c);
+    int myKing = kingpos[me];
+    if (!isCheckbb)
+    {
+        if ((GETPIECE(c) >> 1) == KING)
+        {
+            bool legal = !(isAttacked(to));
+            return legal;
+        }
+        else
+        {
+
+        }
+    }
+
+    return true;
+}
+
+
 bool chessposition::moveGivesCheck(uint32_t c)
 {
     int pc = GETPIECE(c);

--- a/RubiChess/eval.cpp
+++ b/RubiChess/eval.cpp
@@ -433,13 +433,6 @@ int chessposition::getPositionValue()
             result += EVAL(eps.eMaterialvalue[p], S2MSIGN(me));
             if (bTrace) te.material[me] += EVAL(eps.ePsqt[p][psqtindex], S2MSIGN(me)) + EVAL(eps.eMaterialvalue[p], S2MSIGN(me));
 
-            // Penalty for a piece pinning the king
-            if (kingPinned[me] & (BITSET(index)))
-            {
-                result += EVAL(eps.eKingpinpenalty[p], S2MSIGN(me));
-                if (bTrace) te.mobility[me] += EVAL(eps.eKingpinpenalty[p], S2MSIGN(me));
-            }
-
             U64 attack = 0ULL;
             if (shifting[p] & 0x2) // rook and queen
             {
@@ -465,8 +458,17 @@ int chessposition::getPositionValue()
 
             // mobility bonus
             U64 mobility = attack & goodMobility[me];
-            result += EVAL(eps.eMobilitybonus[p - 2][POPCOUNT(mobility)], S2MSIGN(me));
-            if (bTrace) te.mobility[me] += EVAL(eps.eMobilitybonus[p - 2][POPCOUNT(mobility)], S2MSIGN(me));
+
+            // Penalty for a piece pinning the king
+            if (kingPinned[me] & (BITSET(index)))
+            {
+                result += EVAL(eps.eKingpinpenalty[p], S2MSIGN(me));
+                if (bTrace) te.mobility[me] += EVAL(eps.eKingpinpenalty[p], S2MSIGN(me));
+            }
+            else {
+                result += EVAL(eps.eMobilitybonus[p - 2][POPCOUNT(mobility)], S2MSIGN(me));
+                if (bTrace) te.mobility[me] += EVAL(eps.eMobilitybonus[p - 2][POPCOUNT(mobility)], S2MSIGN(me));
+            }
 
             // king danger
             if (mobility & kingdangerarea[you])

--- a/RubiChess/eval.cpp
+++ b/RubiChess/eval.cpp
@@ -459,13 +459,14 @@ int chessposition::getPositionValue()
             // mobility bonus
             U64 mobility = attack & goodMobility[me];
 
-            // Penalty for a piece pinning the king
+            // Penalty for a piece pinned in front of the king
             if (kingPinned[me] & (BITSET(index)))
             {
                 result += EVAL(eps.eKingpinpenalty[p], S2MSIGN(me));
                 if (bTrace) te.mobility[me] += EVAL(eps.eKingpinpenalty[p], S2MSIGN(me));
             }
             else {
+                // Piece is not pinned; give him some mobility bonus
                 result += EVAL(eps.eMobilitybonus[p - 2][POPCOUNT(mobility)], S2MSIGN(me));
                 if (bTrace) te.mobility[me] += EVAL(eps.eMobilitybonus[p - 2][POPCOUNT(mobility)], S2MSIGN(me));
             }
@@ -581,6 +582,7 @@ int chessposition::getValue()
     resetTuner();
 #endif
     ph = phase();
+    updatePins();
     int positionscore = getPositionValue<Et>();
     int sideToScale = positionscore > SCOREDRAW ? WHITE : BLACK;
     sc = getScaling(sideToScale);

--- a/RubiChess/eval.cpp
+++ b/RubiChess/eval.cpp
@@ -97,10 +97,13 @@ static void registertuner(chessposition *pos, eval *e, string name, int index1, 
 void registeralltuners(chessposition *pos)
 {
     int i, j;
-    bool tuneIt = false;
+    bool tuneIt = true;
 
     pos->tps.count = 0;
 
+    for (i = 0; i < 6; i++)
+        registertuner(pos, &eps.eKingpinpenalty[i], "eKingpinpenalty", i, 6, 0, 0, tuneIt && (i > PAWN));
+    tuneIt = false;
     for (i = 0; i < 4; i++)
         for (j = 0; j < 5; j++)
             registertuner(pos, &eps.ePawnstormblocked[i][j], "ePawnstormblocked", j, 5, i, 4, tuneIt);
@@ -127,7 +130,7 @@ void registeralltuners(chessposition *pos)
     registertuner(pos, &eps.eIsolatedpawnpenalty, "eIsolatedpawnpenalty", 0, 0, 0, 0, tuneIt);
     registertuner(pos, &eps.eDoublepawnpenalty, "eDoublepawnpenalty", 0, 0, 0, 0, tuneIt);
 
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 6; i++)
         for (j = 0; j < 5; j++)
             registertuner(pos, &eps.eConnectedbonus[i][j], "eConnectedbonus", j, 5, i, 6, tuneIt);
@@ -136,7 +139,7 @@ void registeralltuners(chessposition *pos)
     tuneIt = false;
     registertuner(pos, &eps.eDoublebishopbonus, "eDoublebishopbonus", 0, 0, 0, 0, tuneIt);
 
-    tuneIt = false;
+    tuneIt = true;
     for (i = 0; i < 4; i++)
         for (j = 0; j < 28; j++)
             registertuner(pos, &eps.eMobilitybonus[i][j], "eMobilitybonus", j, 28, i, 4, tuneIt && (j < maxmobility[i]));
@@ -429,6 +432,13 @@ int chessposition::getPositionValue()
             result += EVAL(eps.ePsqt[p][psqtindex], S2MSIGN(me));
             result += EVAL(eps.eMaterialvalue[p], S2MSIGN(me));
             if (bTrace) te.material[me] += EVAL(eps.ePsqt[p][psqtindex], S2MSIGN(me)) + EVAL(eps.eMaterialvalue[p], S2MSIGN(me));
+
+            // Penalty for a piece pinning the king
+            if (kingPinned[me] & (BITSET(index)))
+            {
+                result += EVAL(eps.eKingpinpenalty[p], S2MSIGN(me));
+                if (bTrace) te.mobility[me] += EVAL(eps.eKingpinpenalty[p], S2MSIGN(me));
+            }
 
             U64 attack = 0ULL;
             if (shifting[p] & 0x2) // rook and queen

--- a/RubiChess/main.cpp
+++ b/RubiChess/main.cpp
@@ -137,7 +137,6 @@ long long engine::perft(int depth, bool dotests)
     else
         movelist.length = rootpos->getMoves(&movelist.move[0]);
 
-    rootpos->updatePins();
     rootpos->prepareStack();
 
     //printf("Path: %s \nMovelist : %s\n", p->actualpath.toString().c_str(), movelist->toString().c_str());

--- a/RubiChess/main.cpp
+++ b/RubiChess/main.cpp
@@ -148,25 +148,11 @@ long long engine::perft(int depth, bool dotests)
     {
         for (int i = 0; i < movelist.length; i++)
         {
-            bool legal = rootpos->moveIsLegal(movelist.move[i].code);
             if (rootpos->playMove(&movelist.move[i]))
             {
                 //printf("%s ok ", movelist->move[i].toString().c_str());
                 retval++;
                 rootpos->unplayMove(&movelist.move[i]);
-                if (!legal) {
-                    printf("Alarm1");
-                    rootpos->print();
-                    printf("Move %s wurde falsch als nicht legal erkannt.\n", movelist.move[i].toString().c_str());
-
-                }
-            }
-            else {
-                if (legal) {
-                    printf("Alarm2");
-                    rootpos->print();
-                    printf("Move %s wurde falsch als legal erkannt.\n", movelist.move[i].toString().c_str());
-                }
             }
         }
     }

--- a/RubiChess/main.cpp
+++ b/RubiChess/main.cpp
@@ -137,6 +137,7 @@ long long engine::perft(int depth, bool dotests)
     else
         movelist.length = rootpos->getMoves(&movelist.move[0]);
 
+    rootpos->updatePins();
     rootpos->prepareStack();
 
     //printf("Path: %s \nMovelist : %s\n", p->actualpath.toString().c_str(), movelist->toString().c_str());
@@ -147,11 +148,25 @@ long long engine::perft(int depth, bool dotests)
     {
         for (int i = 0; i < movelist.length; i++)
         {
+            bool legal = rootpos->moveIsLegal(movelist.move[i].code);
             if (rootpos->playMove(&movelist.move[i]))
             {
                 //printf("%s ok ", movelist->move[i].toString().c_str());
                 retval++;
                 rootpos->unplayMove(&movelist.move[i]);
+                if (!legal) {
+                    printf("Alarm1");
+                    rootpos->print();
+                    printf("Move %s wurde falsch als nicht legal erkannt.\n", movelist.move[i].toString().c_str());
+
+                }
+            }
+            else {
+                if (legal) {
+                    printf("Alarm2");
+                    rootpos->print();
+                    printf("Move %s wurde falsch als legal erkannt.\n", movelist.move[i].toString().c_str());
+                }
             }
         }
     }

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -128,8 +128,6 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         return hashscore;
     }
 
-    updatePins();
-
     if (!myIsCheck)
     {
         bestscore = patscore = (staticeval != NOSCORE ? staticeval : S2MSIGN(state & S2MMASK) * getValue<NOTRACE>());
@@ -168,13 +166,6 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         if (!myIsCheck && patscore + materialvalue[GETCAPTURE(m->code) >> 1] + deltapruningmargin <= alpha)
             // Leave out capture that is delta-pruned
             continue;
-#if 0
-        if (!moveIsLegal(m->code))
-        {
-            //print();
-            continue;
-        }
-#endif
 
         if (playMove(m))
         {
@@ -344,7 +335,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     if (isCheckbb)
         extendall = 1;
 
-    updatePins();
     prepareStack();
 
     // get static evaluation of the position
@@ -523,14 +513,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 extendMove = 1;
             }
         }
-
-#if 0
-        if (!moveIsLegal(m->code))
-        {
-            //print();
-            continue;
-        }
-#endif
 
         if (playMove(m))
         {

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -154,6 +154,7 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         }
     }
 
+    updatePins();
     prepareStack();
 
     MoveSelector ms = {};
@@ -166,6 +167,13 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         if (!myIsCheck && patscore + materialvalue[GETCAPTURE(m->code) >> 1] + deltapruningmargin <= alpha)
             // Leave out capture that is delta-pruned
             continue;
+#if 1
+        if (!moveIsLegal(m->code))
+        {
+            //print();
+            continue;
+        }
+#endif
 
         if (playMove(m))
         {
@@ -336,6 +344,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     if (isCheckbb)
         extendall = 1;
 
+    updatePins();
     prepareStack();
 
     // get static evaluation of the position
@@ -418,6 +427,13 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         {
             if (!see(movelist->move[i].code, rbeta - staticeval))
                 continue;
+#if 0
+            if (!moveIsLegal(movelist->move[i].code))
+            {
+                //print();
+                continue;
+            }
+#endif
 
             if (playMove(&movelist->move[i]))
             {
@@ -455,11 +471,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     uint32_t quietMoves[MAXMOVELISTLENGTH];
     while ((m = ms.next()))
     {
-        if (!moveIsLegal(m->code))
-        {
-            print();
-            continue;
-        }
 #ifdef SDEBUG
         bool isDebugMove = ((debugMove.code & 0xeff) == (m->code & 0xeff));
 #endif
@@ -520,7 +531,18 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
         }
 
+#if 1
+        if (!moveIsLegal(m->code))
+        {
+            //print();
+            continue;
+        }
+#endif
         isLegal = playMove(m);
+        if (!isLegal) {
+            printf("ALarm. Move %s\n", m->toString().c_str());
+            print();
+        }
         if (isLegal)
         {
             LegalMoves++;

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -455,6 +455,11 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     uint32_t quietMoves[MAXMOVELISTLENGTH];
     while ((m = ms.next()))
     {
+        if (!moveIsLegal(m->code))
+        {
+            print();
+            continue;
+        }
 #ifdef SDEBUG
         bool isDebugMove = ((debugMove.code & 0xeff) == (m->code & 0xeff));
 #endif

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -128,6 +128,8 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         return hashscore;
     }
 
+    updatePins();
+
     if (!myIsCheck)
     {
         bestscore = patscore = (staticeval != NOSCORE ? staticeval : S2MSIGN(state & S2MMASK) * getValue<NOTRACE>());
@@ -154,7 +156,6 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         }
     }
 
-    updatePins();
     prepareStack();
 
     MoveSelector ms = {};
@@ -427,7 +428,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         {
             if (!see(movelist->move[i].code, rbeta - staticeval))
                 continue;
-#if 0
+#if 1
             if (!moveIsLegal(movelist->move[i].code))
             {
                 //print();

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -175,8 +175,9 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
             continue;
         }
 #endif
+        playMove(m);
 
-        if (playMove(m))
+        if (true)
         {
             ms.legalmovenum++;
             score = -getQuiescence(-beta, -alpha, depth - 1);
@@ -428,13 +429,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         {
             if (!see(movelist->move[i].code, rbeta - staticeval))
                 continue;
-#if 1
-            if (!moveIsLegal(movelist->move[i].code))
-            {
-                //print();
-                continue;
-            }
-#endif
 
             if (playMove(&movelist->move[i]))
             {
@@ -539,12 +533,9 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             continue;
         }
 #endif
-        isLegal = playMove(m);
-        if (!isLegal) {
-            printf("ALarm. Move %s\n", m->toString().c_str());
-            print();
-        }
-        if (isLegal)
+        playMove(m);
+
+        if (true/*isLegal*/)
         {
             LegalMoves++;
 

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -168,16 +168,15 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         if (!myIsCheck && patscore + materialvalue[GETCAPTURE(m->code) >> 1] + deltapruningmargin <= alpha)
             // Leave out capture that is delta-pruned
             continue;
-#if 1
+#if 0
         if (!moveIsLegal(m->code))
         {
             //print();
             continue;
         }
 #endif
-        playMove(m);
 
-        if (true)
+        if (playMove(m))
         {
             ms.legalmovenum++;
             score = -getQuiescence(-beta, -alpha, depth - 1);
@@ -226,7 +225,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     int hashscore = NOSCORE;
     uint16_t hashmovecode = 0;
     int staticeval = NOSCORE;
-    bool isLegal;
     int bestscore = NOSCORE;
     uint32_t bestcode = 0;
     int eval_type = HASHALPHA;
@@ -526,16 +524,15 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
         }
 
-#if 1
+#if 0
         if (!moveIsLegal(m->code))
         {
             //print();
             continue;
         }
 #endif
-        playMove(m);
 
-        if (true/*isLegal*/)
+        if (playMove(m))
         {
             LegalMoves++;
 


### PR DESCRIPTION
STC[0,5]:
Score of RubiChess-il5 vs RubiChess-ms: 385 - 323 - 602  [0.524] 1310
Elo difference: 16.46 +/- 13.82
SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted

LTC[0,5]:
Score of RubiChess-il5 vs RubiChess-ms: 678 - 614 - 1601  [0.511] 2893
Elo difference: 7.69 +/- 8.45
SPRT: llr 1.39, lbound -1.39, ubound 1.39 - H1 was accepted