### PR TITLE
Kingsupportspasser

### DIFF
--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -267,32 +267,32 @@ struct evalparamset {
     eval eHangingpiecepenalty =  VALUE( -23, -36);
     eval eTempo =  VALUE(  30,  27);
     eval ePassedpawnbonus[4][8] = {
-        {  VALUE(   0,   0), VALUE(  10,   4), VALUE(   0,   8), VALUE(  10,  25), VALUE(  37,  39), VALUE(  76,  71), VALUE(  44, 108), VALUE(   0,   0)  },
-        {  VALUE(   0,   0), VALUE( -19,  -5), VALUE( -15,  12), VALUE(  -5,  17), VALUE(  17,  31), VALUE(  38,  38), VALUE( -12,  11), VALUE(   0,   0)  },
-        {  VALUE(   0,   0), VALUE(   3,   7), VALUE(   6,  12), VALUE(  10,  41), VALUE(  26,  95), VALUE(  67, 200), VALUE( 120, 301), VALUE(   0,   0)  },
-        {  VALUE(   0,   0), VALUE(   9,   7), VALUE(  -3,  21), VALUE(   1,  39), VALUE(  16,  54), VALUE(  58,  73), VALUE(  34,  55), VALUE(   0,   0)  }
+        {  VALUE(   0,   0), VALUE(  10,   4), VALUE(   0,   8), VALUE(  10,  25), VALUE(  35,  46), VALUE(  74,  81), VALUE(  44, 108), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE( -19,  -4), VALUE( -15,  12), VALUE(  -5,  17), VALUE(  17,  34), VALUE(  42,  60), VALUE( -12,  42), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(   3,   7), VALUE(   6,  12), VALUE(  10,  41), VALUE(  26,  95), VALUE(  64, 197), VALUE( 105, 289), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(   9,   7), VALUE(  -3,  19), VALUE(   1,  39), VALUE(  16,  54), VALUE(  58,  73), VALUE(  19,  69), VALUE(   0,   0)  }
     };
     eval eKingsupportspasserbonus[7][8] = {
-        {  VALUE(0,   0), VALUE(13,   7), VALUE(32,  -6), VALUE(57,  -6), VALUE(73, -13), VALUE(138, -31), VALUE(145, -22), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(18,   7), VALUE(-8,   7), VALUE(10,   0), VALUE(18, -21), VALUE(101, -73), VALUE(151, -71), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(21,  -2), VALUE(-7,   0), VALUE(-6, -16), VALUE(-15, -41), VALUE(37, -84), VALUE(120,-124), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(5,   6), VALUE(-7,   7), VALUE(-5, -23), VALUE(-28, -45), VALUE(-22, -78), VALUE(34,-110), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(16,   3), VALUE(13, -13), VALUE(6, -22), VALUE(-5, -60), VALUE(-57, -70), VALUE(27,-105), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(11,   7), VALUE(19,  -6), VALUE(35, -27), VALUE(2, -49), VALUE(1,-100), VALUE(-39, -67), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(-11,  18), VALUE(-29,  21), VALUE(15, -27), VALUE(-8, -58), VALUE(-17, -92), VALUE(-39, -97), VALUE(0,   0)  }
+        {  VALUE(   0,   0), VALUE(  13,   7), VALUE(  30,  -6), VALUE(  57,  -6), VALUE(  72, -13), VALUE( 138, -32), VALUE( 143, -23), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(  18,   7), VALUE(  -8,   7), VALUE(  10,   0), VALUE(  18, -21), VALUE( 107, -73), VALUE( 151, -70), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(  21,  -3), VALUE(  -7,   0), VALUE(  -6, -16), VALUE( -15, -41), VALUE(  37, -82), VALUE( 122,-120), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(   9,   6), VALUE(  -7,   7), VALUE(  -5, -17), VALUE( -28, -45), VALUE( -23, -79), VALUE(  34,-111), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(  10,   3), VALUE(  11, -13), VALUE(   6, -22), VALUE(  -6, -62), VALUE( -57, -73), VALUE(  12,-104), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(   9,   7), VALUE(  19,  -6), VALUE(  37, -29), VALUE(  -1, -52), VALUE(   1, -99), VALUE( -39, -67), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE( -11,  18), VALUE( -30,  21), VALUE(   9, -27), VALUE( -10, -61), VALUE( -17, -92), VALUE( -39, -97), VALUE(   0,   0)  }
     };
     eval eKingdefendspasserpenalty[7][8] = {
-        {  VALUE(0,   0), VALUE(-5,  18), VALUE(-15,  43), VALUE(10,  16), VALUE(-5,  37), VALUE(34,  25), VALUE(29,  -9), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(37,   4), VALUE(10,  -1), VALUE(12,   4), VALUE(42,   3), VALUE(45,   7), VALUE(1,  53), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(31,  -3), VALUE(6,   2), VALUE(11,   2), VALUE(28,  18), VALUE(56,  69), VALUE(29,  97), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(11,  -2), VALUE(5,  -1), VALUE(1,   5), VALUE(21,  69), VALUE(49, 115), VALUE(11, 144), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(6, -17), VALUE(0,  -3), VALUE(-8,  40), VALUE(14,  82), VALUE(48, 121), VALUE(10, 153), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(-17,  -5), VALUE(-15,  15), VALUE(-9,  29), VALUE(13,  73), VALUE(7, 143), VALUE(34, 138), VALUE(0,   0)  },
-        {  VALUE(0,   0), VALUE(-33, -11), VALUE(-29,  12), VALUE(-9,  29), VALUE(-1,  66), VALUE(6, 125), VALUE(81,  77), VALUE(0,   0)  }
+        {  VALUE(   0,   0), VALUE(  62,   4), VALUE( -15,  49), VALUE(  10,  16), VALUE(  -5,  37), VALUE(  36,  18), VALUE(  23, -18), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(  37,   4), VALUE(  10,  -1), VALUE(  12,   4), VALUE(  40,   0), VALUE(  45,   7), VALUE(  16,  53), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(  38,  -3), VALUE(  11,   1), VALUE(  11,   2), VALUE(  28,  18), VALUE(  56,  69), VALUE(  29,  97), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(  11,  -2), VALUE(   5,  -1), VALUE(   1,   5), VALUE(  21,  69), VALUE(  43, 118), VALUE(   3, 145), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(   1, -13), VALUE(   0,  -3), VALUE(  -8,  40), VALUE(  14,  82), VALUE(  48, 121), VALUE(   9, 152), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE( -17,  -5), VALUE( -15,  15), VALUE(  -7,  31), VALUE(  13,  73), VALUE(   7, 143), VALUE(  34, 138), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE( -33,  -3), VALUE( -29,  18), VALUE( -11,  31), VALUE(   0,  70), VALUE(   6, 125), VALUE(  83,  77), VALUE(   0,   0)  }
     };
     eval ePotentialpassedpawnbonus[2][8] = {
-        {  VALUE(   0,   0), VALUE(  28, -15), VALUE(  -6,   4), VALUE(  13,   5), VALUE(  32,  51), VALUE(  72,  81), VALUE(  44, 108), VALUE(   0,   0)  },
-        {  VALUE(   0,   0), VALUE(  -1,  -3), VALUE(   0,  -3), VALUE(   5,   5), VALUE(  21,  33), VALUE(  58,  62), VALUE( -14,  10), VALUE(   0,   0)  }
+        {  VALUE(   0,   0), VALUE(  28, -15), VALUE(  -3,  14), VALUE(  17,   5), VALUE(  37,  60), VALUE(  75,  81), VALUE(  44, 108), VALUE(   0,   0)  },
+        {  VALUE(   0,   0), VALUE(  -2,   0), VALUE(   1,   2), VALUE(   6,   6), VALUE(  20,  25), VALUE(  53,   7), VALUE( -14,  10), VALUE(   0,   0)  }
     };
     eval eAttackingpawnbonus[8] = {  VALUE(   0,   0), VALUE( -48,  12), VALUE( -14,   4), VALUE( -14,  -6), VALUE( -14,  -6), VALUE( -15,   1), VALUE(   0,   0), VALUE(   0,   0)  };
     eval eIsolatedpawnpenalty =  VALUE( -13, -12);

--- a/RubiChess/RubiChess.h
+++ b/RubiChess/RubiChess.h
@@ -272,6 +272,24 @@ struct evalparamset {
         {  VALUE(   0,   0), VALUE(   3,   7), VALUE(   6,  12), VALUE(  10,  41), VALUE(  26,  95), VALUE(  67, 200), VALUE( 120, 301), VALUE(   0,   0)  },
         {  VALUE(   0,   0), VALUE(   9,   7), VALUE(  -3,  21), VALUE(   1,  39), VALUE(  16,  54), VALUE(  58,  73), VALUE(  34,  55), VALUE(   0,   0)  }
     };
+    eval eKingsupportspasserbonus[7][8] = {
+        {  VALUE(0,   0), VALUE(13,   7), VALUE(32,  -6), VALUE(57,  -6), VALUE(73, -13), VALUE(138, -31), VALUE(145, -22), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(18,   7), VALUE(-8,   7), VALUE(10,   0), VALUE(18, -21), VALUE(101, -73), VALUE(151, -71), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(21,  -2), VALUE(-7,   0), VALUE(-6, -16), VALUE(-15, -41), VALUE(37, -84), VALUE(120,-124), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(5,   6), VALUE(-7,   7), VALUE(-5, -23), VALUE(-28, -45), VALUE(-22, -78), VALUE(34,-110), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(16,   3), VALUE(13, -13), VALUE(6, -22), VALUE(-5, -60), VALUE(-57, -70), VALUE(27,-105), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(11,   7), VALUE(19,  -6), VALUE(35, -27), VALUE(2, -49), VALUE(1,-100), VALUE(-39, -67), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(-11,  18), VALUE(-29,  21), VALUE(15, -27), VALUE(-8, -58), VALUE(-17, -92), VALUE(-39, -97), VALUE(0,   0)  }
+    };
+    eval eKingdefendspasserpenalty[7][8] = {
+        {  VALUE(0,   0), VALUE(-5,  18), VALUE(-15,  43), VALUE(10,  16), VALUE(-5,  37), VALUE(34,  25), VALUE(29,  -9), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(37,   4), VALUE(10,  -1), VALUE(12,   4), VALUE(42,   3), VALUE(45,   7), VALUE(1,  53), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(31,  -3), VALUE(6,   2), VALUE(11,   2), VALUE(28,  18), VALUE(56,  69), VALUE(29,  97), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(11,  -2), VALUE(5,  -1), VALUE(1,   5), VALUE(21,  69), VALUE(49, 115), VALUE(11, 144), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(6, -17), VALUE(0,  -3), VALUE(-8,  40), VALUE(14,  82), VALUE(48, 121), VALUE(10, 153), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(-17,  -5), VALUE(-15,  15), VALUE(-9,  29), VALUE(13,  73), VALUE(7, 143), VALUE(34, 138), VALUE(0,   0)  },
+        {  VALUE(0,   0), VALUE(-33, -11), VALUE(-29,  12), VALUE(-9,  29), VALUE(-1,  66), VALUE(6, 125), VALUE(81,  77), VALUE(0,   0)  }
+    };
     eval ePotentialpassedpawnbonus[2][8] = {
         {  VALUE(   0,   0), VALUE(  28, -15), VALUE(  -6,   4), VALUE(  13,   5), VALUE(  32,  51), VALUE(  72,  81), VALUE(  44, 108), VALUE(   0,   0)  },
         {  VALUE(   0,   0), VALUE(  -1,  -3), VALUE(   0,  -3), VALUE(   5,   5), VALUE(  21,  33), VALUE(  58,  62), VALUE( -14,  10), VALUE(   0,   0)  }

--- a/RubiChess/board.cpp
+++ b/RubiChess/board.cpp
@@ -40,7 +40,7 @@ U64 lineMask[64][64];
 int castleindex[64][64] = { 0 };
 U64 castlekingto[64][2] = { 0ULL };
 int castlerights[64];
-int squareDistance[64][64];
+int squareDistance[64][64];  // decreased by 1 for directly indexing evaluation arrays
 
 
 PieceType GetPieceType(char c)
@@ -1147,7 +1147,7 @@ void initBitmaphelper()
 
         for (int j = 0; j < 64; j++)
         {
-            squareDistance[from][j] = max(abs(RANK(from) - RANK(j)), abs(FILE(from) - FILE(j)));
+            squareDistance[from][j] = max(abs(RANK(from) - RANK(j)), abs(FILE(from) - FILE(j))) - 1;
             betweenMask[from][j] = 0ULL;
             lineMask[from][j] = 0ULL;
             

--- a/RubiChess/eval.cpp
+++ b/RubiChess/eval.cpp
@@ -116,7 +116,7 @@ void registeralltuners(chessposition *pos)
     tuneIt = false;
     registertuner(pos, &eps.eHangingpiecepenalty, "eHangingpiecepenalty", 0, 0, 0, 0, tuneIt);
     registertuner(pos, &eps.eTempo, "eTempo", 0, 0, 0, 0, tuneIt);
-    tuneIt = false;
+    tuneIt = true;
     for (i = 0; i < 4; i++)
         for (j = 0; j < 8; j++)
             registertuner(pos, &eps.ePassedpawnbonus[i][j], "ePassedpawnbonus", j, 8, i, 4, tuneIt && (j > 0 && j < 7));
@@ -128,7 +128,7 @@ void registeralltuners(chessposition *pos)
         for (j = 0; j < 8; j++)
             registertuner(pos, &eps.eKingdefendspasserpenalty[i][j], "eKingdefendspasserpenalty", j, 8, i, 7, tuneIt && (j > 0 && j < 7));
 
-    tuneIt = false;
+    tuneIt = true;
     for (i = 0; i < 2; i++)
         for (j = 0; j < 8; j++)
             registertuner(pos, &eps.ePotentialpassedpawnbonus[i][j], "ePotentialpassedpawnbonus", j, 8, i, 2, tuneIt && (j > 0 && j < 7));

--- a/RubiChess/eval.cpp
+++ b/RubiChess/eval.cpp
@@ -97,13 +97,13 @@ static void registertuner(chessposition *pos, eval *e, string name, int index1, 
 void registeralltuners(chessposition *pos)
 {
     int i, j;
-    bool tuneIt = true;
+    bool tuneIt = false;
 
     pos->tps.count = 0;
 
     for (i = 0; i < 6; i++)
         registertuner(pos, &eps.eKingpinpenalty[i], "eKingpinpenalty", i, 6, 0, 0, tuneIt && (i > PAWN));
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 4; i++)
         for (j = 0; j < 5; j++)
             registertuner(pos, &eps.ePawnstormblocked[i][j], "ePawnstormblocked", j, 5, i, 4, tuneIt);
@@ -113,49 +113,57 @@ void registeralltuners(chessposition *pos)
 
     registertuner(pos, &eps.ePawnpushthreatbonus, "ePawnpushthreatbonus", 0, 0, 0, 0, tuneIt);
     registertuner(pos, &eps.eSafepawnattackbonus, "eSafepawnattackbonus", 0, 0, 0, 0, tuneIt);
-    tuneIt = true;
+    tuneIt = false;
     registertuner(pos, &eps.eHangingpiecepenalty, "eHangingpiecepenalty", 0, 0, 0, 0, tuneIt);
     registertuner(pos, &eps.eTempo, "eTempo", 0, 0, 0, 0, tuneIt);
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 4; i++)
         for (j = 0; j < 8; j++)
             registertuner(pos, &eps.ePassedpawnbonus[i][j], "ePassedpawnbonus", j, 8, i, 4, tuneIt && (j > 0 && j < 7));
     tuneIt = true;
+    for (i = 0; i < 7; i++)
+        for (j = 0; j < 8; j++)
+            registertuner(pos, &eps.eKingsupportspasserbonus[i][j], "eKingsupportspasserbonus", j, 8, i, 7, tuneIt && (j > 0 && j < 7));
+    for (i = 0; i < 7; i++)
+        for (j = 0; j < 8; j++)
+            registertuner(pos, &eps.eKingdefendspasserpenalty[i][j], "eKingdefendspasserpenalty", j, 8, i, 7, tuneIt && (j > 0 && j < 7));
+
+    tuneIt = false;
     for (i = 0; i < 2; i++)
         for (j = 0; j < 8; j++)
             registertuner(pos, &eps.ePotentialpassedpawnbonus[i][j], "ePotentialpassedpawnbonus", j, 8, i, 2, tuneIt && (j > 0 && j < 7));
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 8; i++)
         registertuner(pos, &eps.eAttackingpawnbonus[i], "eAttackingpawnbonus", i, 8, 0, 0, tuneIt && (i > 0 && i < 7));
     registertuner(pos, &eps.eIsolatedpawnpenalty, "eIsolatedpawnpenalty", 0, 0, 0, 0, tuneIt);
     registertuner(pos, &eps.eDoublepawnpenalty, "eDoublepawnpenalty", 0, 0, 0, 0, tuneIt);
 
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 6; i++)
         for (j = 0; j < 5; j++)
             registertuner(pos, &eps.eConnectedbonus[i][j], "eConnectedbonus", j, 5, i, 6, tuneIt);
 
     registertuner(pos, &eps.eBackwardpawnpenalty, "eBackwardpawnpenalty", 0, 0, 0, 0, tuneIt);
-    tuneIt = true;
+    tuneIt = false;
     registertuner(pos, &eps.eDoublebishopbonus, "eDoublebishopbonus", 0, 0, 0, 0, tuneIt);
 
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 4; i++)
         for (j = 0; j < 28; j++)
             registertuner(pos, &eps.eMobilitybonus[i][j], "eMobilitybonus", j, 28, i, 4, tuneIt && (j < maxmobility[i]));
 
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 2; i++)
         registertuner(pos, &eps.eSlideronfreefilebonus[i], "eSlideronfreefilebonus", i, 2, 0, 0, tuneIt);
     for (i = 0; i < 7; i++)
         registertuner(pos, &eps.eMaterialvalue[i], "eMaterialvalue", i, 7, 0, 0, false);
     registertuner(pos, &eps.eKingshieldbonus, "eKingshieldbonus", 0, 0, 0, 0, tuneIt);
-    tuneIt = true;
+    tuneIt = false;
     registertuner(pos, &eps.eWeakkingringpenalty, "eWeakkingringpenalty", 0, 0, 0, 0, tuneIt);
     for (i = 0; i < 7; i++)
         registertuner(pos, &eps.eKingattackweight[i], "eKingattackweight", i, 7, 0, 0, tuneIt && (i >= KNIGHT && i <= QUEEN));
 
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 6; i++)
         registertuner(pos, &eps.eSafecheckbonus[i], "eSafecheckbonus", i, 6, 0, 0, tuneIt && (i >= KNIGHT && i <= QUEEN));
     registertuner(pos, &eps.eKingdangerbyqueen, "eKingdangerbyqueen", 0, 0, 0, 0, tuneIt);
@@ -164,7 +172,7 @@ void registeralltuners(chessposition *pos)
 
     registertuner(pos, &eps.eKingdangeradjust, "eKingdangeradjust", 0, 0, 0, 0, tuneIt);
     
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 7; i++)
         for (j = 0; j < 64; j++)
             registertuner(pos, &eps.ePsqt[i][j], "ePsqt", j, 64, i, 7, tuneIt && (i >= KNIGHT || (i == PAWN && j >= 8 && j < 56)));
@@ -254,6 +262,12 @@ int chessposition::getPawnAndKingValue(pawnhashentry **entry)
                 {
                     // passed pawn
                     entryptr->passedpawnbb[me] |= BITSET(index);
+                    int mykingdistance = squareDistance[index][kingpos[me]];
+                    int yourkingdistance = squareDistance[index][kingpos[you]];
+                    entryptr->value += EVAL(eps.eKingsupportspasserbonus[mykingdistance][RRANK(index, me)], S2MSIGN(me));
+                    if (bTrace) te.pawns[me] += EVAL(eps.eKingsupportspasserbonus[mykingdistance][RRANK(index, me)], S2MSIGN(me));
+                    entryptr->value += EVAL(eps.eKingdefendspasserpenalty[yourkingdistance][RRANK(index, me)], S2MSIGN(me));
+                    if (bTrace) te.pawns[me] += EVAL(eps.eKingdefendspasserpenalty[yourkingdistance][RRANK(index, me)], S2MSIGN(me));
                 }
                 else {
                     // test for potential passer


### PR DESCRIPTION
kpa2
STC[0,5]:
Score of RubiChess-kpa2 vs RubiChess-ms: 388 - 323 - 521  [0.526] 1232
Elo difference: 18.35 +/- 14.73
SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted

LTC[0,5]
Score of RubiChess-kpa2 vs RubiChess-ms: 161 - 114 - 354  [0.537] 629
Elo difference: 26.01 +/- 17.93
SPRT: llr 1.41, lbound -1.39, ubound 1.39 - H1 was accepted

Wow!!!