### PR TITLE
Mc2

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -512,7 +512,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 SDEBUGPRINT(isDebugPv && isDebugMove, debugInsert, " PV move %s is singular", debugMove.toString().c_str());
                 extendMove = 1;
             }
-            else if (staticeval >= beta && sBeta >= beta)
+            else if (bestknownscore >= beta && sBeta >= beta)
             {
                 // Hashscore for lower depth and static eval cut and we have at least a second good move => lets cut here
                 return sBeta;

--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -512,6 +512,11 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 SDEBUGPRINT(isDebugPv && isDebugMove, debugInsert, " PV move %s is singular", debugMove.toString().c_str());
                 extendMove = 1;
             }
+            else if (staticeval >= beta && sBeta >= beta)
+            {
+                // Hashscore for lower depth and static eval cut and we have at least a second good move => lets cut here
+                return sBeta;
+            }
         }
 
         if (playMove(m))

--- a/Tests/_temp/cu.txt
+++ b/Tests/_temp/cu.txt
@@ -1,0 +1,7 @@
+Multi-cut / reduction on cut nodes
+
+STC[0,5]:
+Score of RubiChess-cu5 vs RubiChess-ms: 1027 - 949 - 1801  [0.510] 3777
+Elo difference: 7.18 +/- 8.00
+SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted
+


### PR DESCRIPTION
LTC[0,5]:
Score of RubiChess-mc3 vs RubiChess-ms: 709 - 645 - 1867  [0.510] 3221
Elo difference: 6.90 +/- 7.77
SPRT: llr 1.4, lbound -1.39, ubound 1.39 - H1 was accepted