### PR TITLE
Moved check for immediate stop to the beginning of alphabeta(). This …

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -250,6 +250,11 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         return SCOREDRAW;
     }
 
+    if (en.stopLevel == ENGINESTOPIMMEDIATELY)
+    {
+        // time is over; immediate stop requested
+        return alpha;
+    }
 
     // Reached depth? Do a qsearch
     if (depth <= 0)
@@ -567,12 +572,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 }
             }
             unplayMove(m);
-
-            if (en.stopLevel == ENGINESTOPIMMEDIATELY)
-            {
-                // time is over; immediate stop requested
-                return alpha;
-            }
 
             SDEBUGPRINT(isDebugPv && isDebugMove, debugInsert, " PV move %s scored %d", debugMove.toString().c_str(), score);
 


### PR DESCRIPTION
…should hopefully fix the timeloss issue in TCEC match against Texel.

Tested 50 games with 15 threads against master starting at the position before time loss against texel
with a convincing
Score of RubiChess-tl vs RubiChess-ms: 13 - 0 - 37  [0.630] 50