### PR TITLE
Badcmpruning

### DIFF
--- a/RubiChess/search.cpp
+++ b/RubiChess/search.cpp
@@ -559,6 +559,18 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
         }
 
+        int stats = getHistory(m->code, ms.cmptr);
+        int reduction = ISTACTICAL(m->code) ? 0 :reductiontable[positionImproved][depth][min(63, LegalMoves + 1)];
+        int pc = GETPIECE(m->code);
+        int to = GETTO(m->code);
+        effectiveDepth = depth + extendall - reduction + extendMove;
+
+        // Prune moves with bad counter move history
+        if (!ISTACTICAL(m->code) && effectiveDepth < 4
+            && ms.cmptr[0] && ms.cmptr[0][pc * 64 + to] < 0
+            && ms.cmptr[1] && ms.cmptr[1][pc * 64 + to] < 0)
+            continue;
+
         if (playMove(m))
         {
             LegalMoves++;
@@ -571,12 +583,9 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 continue;
             }
 
-            int stats = getHistory(m->code, ms.cmptr);
-            int reduction = 0;
             // Late move reduction
-            if (!extendall && depth > 2 && !ISTACTICAL(m->code))
+            if (depth > 2 && !ISTACTICAL(m->code))
             {
-                reduction = reductiontable[positionImproved][depth][min(63, LegalMoves)];
                 SDEBUGPRINT(isDebugPv && isDebugMove && reduction, debugInsert, " PV move %s (value=%d) with depth reduced by %d", debugMove.toString().c_str(), m->value, reduction);
 
                 // adjust reduction by stats value
@@ -587,7 +596,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             if (eval_type != HASHEXACT)
             {
                 // First move ("PV-move"); do a normal search
-                effectiveDepth = depth + extendall - reduction + extendMove;
                 score = -alphabeta(-beta, -alpha, effectiveDepth - 1);
                 if (reduction && score > alpha)
                 {
@@ -598,7 +606,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
             else {
                 // try a PV-Search
-                effectiveDepth = depth + extendall;
                 score = -alphabeta(-alpha - 1, -alpha, effectiveDepth - 1);
                 if (score > alpha && score < beta)
                 {


### PR DESCRIPTION
All three tests passed very fast. LTC[0,5]:
Score of RubiChess-cmp2 vs RubiChess-cms: 219 - 171 - 510  [0.527] 900
Elo difference: 18.55 +/- 14.92
SPRT: llr 1.39, lbound -1.39, ubound 1.39 - H1 was accepted
Also the Arasan20 test suite gets ~10 more hits with this patch. 
This is a VERY good one.