### PR TITLE
pvs fix (Tt at pv)

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -670,26 +670,26 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
         LegalMoves[mstop] = ms.legalmovenum;
 
-        if (eval_type != HASHEXACT)
+        if (reduction)
         {
-            // First move ("PV-move"); do a normal search
-            score = -alphabeta(-beta, -alpha, effectiveDepth - 1);
-            if (reduction && score > alpha)
+            // LMR search; test against alpha
+            score = -alphabeta(-alpha - 1, -alpha, effectiveDepth - 1);
+            if (score > alpha)
             {
                 // research without reduction
                 effectiveDepth += reduction;
-                score = -alphabeta(-beta, -alpha, effectiveDepth - 1);
+                score = -alphabeta(-alpha - 1, -alpha, effectiveDepth - 1);
             }
         }
-        else {
-            // try a PV-Search
+        else if (!PVNode || legalMoves > 1)
+        {
+            // Np PV node or not the first move; test against alpha
             score = -alphabeta(-alpha - 1, -alpha, effectiveDepth - 1);
-            if (score > alpha && score < beta)
-            {
-                // reasearch with full window
-                score = -alphabeta(-beta, -alpha, effectiveDepth - 1);
-            }
         }
+        // (re)search with full window at PV nodes or if necessary
+        if (PVNode && (legalMoves == 1 || score > alpha))
+            score = -alphabeta(-beta, -alpha, effectiveDepth - 1);
+
         unplayMove(m);
 
         if (en.stopLevel == ENGINESTOPIMMEDIATELY)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -686,7 +686,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             // Np PV node or not the first move; test against alpha
             score = -alphabeta(-alpha - 1, -alpha, effectiveDepth - 1);
         }
-        // (re)search with full window at PV nodes or if necessary
+        // (re)search with full window at PV nodes if necessary
         if (PVNode && (legalMoves == 1 || score > alpha))
             score = -alphabeta(-beta, -alpha, effectiveDepth - 1);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -257,7 +257,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     chessmove *m;
     int extendall = 0;
     int effectiveDepth;
-    bool PVNode = (alpha != beta - 1);
+    const bool PVNode = (alpha != beta - 1);
 
     nodes++;
 
@@ -355,7 +355,8 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 updatePvTable(fullhashmove, false);
             SDEBUGPRINT(isDebugPv, debugInsert, " Got score %d from TT.", hashscore);
             STATISTICSINC(ab_tt);
-            return hashscore;
+            if (!PVNode)
+                return hashscore;
         }
     }
 


### PR DESCRIPTION
STC:
ELO   | 4.33 +- 3.45 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19318 W: 4929 L: 4688 D: 9701

LTC:
ELO   | 19.62 +- 8.46 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2428 W: 524 L: 387 D: 1517
