### PR TITLE
Searchparams

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -792,7 +792,6 @@ int chessposition::rootsearch(int alpha, int beta, int depth)
     int staticeval = NOSCORE;
     int eval_type = HASHALPHA;
     chessmove *m;
-    int extendall = 0;
     int lastmoveindex;
     int maxmoveindex;
 
@@ -839,10 +838,7 @@ int chessposition::rootsearch(int alpha, int beta, int depth)
             return score;
         }
     }
-#if 0
-    if (isCheckbb)
-        extendall = 1;
-#endif
+
     if (!tbPosition)
     {
         // Reset move values
@@ -901,12 +897,12 @@ int chessposition::rootsearch(int alpha, int beta, int depth)
         int reduction = 0;
 
         // Late move reduction
-        if (!extendall && depth > 2 && !ISTACTICAL(m->code))
+        if (depth > 2 && !ISTACTICAL(m->code))
         {
             reduction = reductiontable[1][depth][min(63, i + 1)];
         }
 
-        int effectiveDepth = depth + extendall - reduction;
+        int effectiveDepth = depth - reduction;
 
         if (reduction)
         {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -431,10 +431,10 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
     // futility pruning
     bool futility = false;
-    if (depth <= 6)
+    if (depth <= 8)
     {
         // reverse futility pruning
-        if (!isCheckbb && staticeval - depth * (72 - 20 * positionImproved) > beta)
+        if (!isCheckbb && staticeval - depth * (90 - 20 * positionImproved) > beta)
         {
             SDEBUGPRINT(isDebugPv, debugInsert, " Cutoff by reverse futility pruning: staticscore(%d) - revMargin(%d) > beta(%d)", staticeval, depth * (72 - 20 * positionImproved), beta);
             STATISTICSINC(prune_futility);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -434,7 +434,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     if (depth <= 8)
     {
         // reverse futility pruning
-        if (!isCheckbb && staticeval - depth * (90 - 20 * positionImproved) > beta)
+        if (!isCheckbb && staticeval - depth * (70 - 20 * positionImproved) > beta)
         {
             SDEBUGPRINT(isDebugPv, debugInsert, " Cutoff by reverse futility pruning: staticscore(%d) - revMargin(%d) > beta(%d)", staticeval, depth * (72 - 20 * positionImproved), beta);
             STATISTICSINC(prune_futility);
@@ -839,10 +839,10 @@ int chessposition::rootsearch(int alpha, int beta, int depth)
             return score;
         }
     }
-
+#if 0
     if (isCheckbb)
         extendall = 1;
-
+#endif
     if (!tbPosition)
     {
         // Reset move values


### PR DESCRIPTION
STC:
ELO   | 9.38 +- 5.88 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6003 W: 1428 L: 1266 D: 3309

LTC:
ELO   | 5.68 +- 3.94 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.02 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10463 W: 1927 L: 1756 D: 6780
