### PR TITLE
Resetstats

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1035,9 +1035,6 @@ public:
     chessmove pondermove;
     int LegalMoves[MAXDEPTH];
     uint32_t killer[MAXDEPTH][2];
-    uint32_t countermove[14][64];
-    int16_t history[2][64][64];
-    int16_t counterhistory[14][64][14*64];
     uint32_t bestFailingLow;
     Pawnhash *pwnhsh;
     int threadindex;
@@ -1074,6 +1071,11 @@ public:
     void copyPositionTuneSet(positiontuneset *from, evalparam *efrom, positiontuneset *to, evalparam *eto);
     string getGradientString();
 #endif
+    // ...
+    int16_t history[2][64][64];
+    int16_t counterhistory[14][64][14 * 64];
+    uint32_t countermove[14][64];
+
     bool w2m();
     void BitboardSet(int index, PieceCode p);
     void BitboardClear(int index, PieceCode p);
@@ -1222,6 +1224,7 @@ public:
     void resetPonder() { pondersearch = NO; }
     long long perft(int depth, bool dotests);
     void prepareThreads();
+    void resetStats();
 };
 
 PieceType GetPieceType(char c);

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -2356,7 +2356,7 @@ void engine::allocThreads()
     }
     allocPawnhash();
     prepareThreads();
-    resetStats();
+    //resetStats();
 }
 
 
@@ -2365,6 +2365,7 @@ void engine::prepareThreads()
     for (int i = 0; i < Threads; i++)
     {
         memcpy(&sthread[i].pos, &rootposition, offsetof(chessposition, history));
+        resetStats();
         sthread[i].pos.threadindex = i;
         // early reset of variables that are important for bestmove selection
         sthread[i].pos.bestmovescore[0] = NOSCORE;

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -2356,7 +2356,7 @@ void engine::allocThreads()
     }
     allocPawnhash();
     prepareThreads();
-    //resetStats();
+    resetStats();
 }
 
 
@@ -2365,7 +2365,6 @@ void engine::prepareThreads()
     for (int i = 0; i < Threads; i++)
     {
         memcpy(&sthread[i].pos, &rootposition, offsetof(chessposition, history));
-        resetStats();
         sthread[i].pos.threadindex = i;
         // early reset of variables that are important for bestmove selection
         sthread[i].pos.bestmovescore[0] = NOSCORE;

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -391,10 +391,6 @@ int chessposition::getFromFen(const char* sFen)
     hash = zb.getHash(this);
     pawnhash = zb.getPawnHash(this);
     materialhash = zb.getMaterialHash(this);
-    memset(history, 0, sizeof(history));
-    memset(counterhistory, 0, sizeof(counterhistory));
-    memset(killer, 0, sizeof(killer));
-    memset(countermove, 0, sizeof(countermove));
     mstop = 0;
     rootheight = 0;
     lastnullmove = -1;
@@ -2360,6 +2356,7 @@ void engine::allocThreads()
     }
     allocPawnhash();
     prepareThreads();
+    resetStats();
 }
 
 
@@ -2367,7 +2364,7 @@ void engine::prepareThreads()
 {
     for (int i = 0; i < Threads; i++)
     {
-        sthread[i].pos = rootposition;
+        memcpy(&sthread[i].pos, &rootposition, offsetof(chessposition, history));
         sthread[i].pos.threadindex = i;
         // early reset of variables that are important for bestmove selection
         sthread[i].pos.bestmovescore[0] = NOSCORE;
@@ -2375,6 +2372,16 @@ void engine::prepareThreads()
         sthread[i].pos.nodes = 0;
         sthread[i].pos.nullmoveply = 0;
         sthread[i].pos.nullmoveside = 0;
+    }
+}
+
+void engine::resetStats()
+{
+    for (int i = 0; i < Threads; i++)
+    {
+        memset(sthread[i].pos.history, 0, sizeof(chessposition::history));
+        memset(sthread[i].pos.counterhistory, 0, sizeof(chessposition::counterhistory));
+        memset(sthread[i].pos.countermove, 0, sizeof(chessposition::countermove));
     }
 }
 
@@ -2579,8 +2586,9 @@ void engine::communicate(string inputstring)
                 send("uciok\n", author);
                 break;
             case UCINEWGAME:
-                // invalidate hash
+                // invalidate hash and history
                 tp.clean();
+                resetStats();
                 sthread[0].pos.lastbestmovescore = NOSCORE;
                 break;
             case SETOPTION:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -484,7 +484,7 @@ static void doBenchmark(int constdepth, string epdfilename, int consttime, int s
 
         if (++i < startnum) continue;
 
-        en.communicate("ucinewgame" + bm->fen);
+        en.communicate("ucinewgame");
         en.communicate("position fen " + bm->fen);
         starttime = getTime();
         int dp = 0;


### PR DESCRIPTION
STC (Openbench):
ELO   | 23.91 +- 9.04 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 2576 W: 673 L: 496 D: 1407

LTC:
(+112,=392,- 62), 54.4 %

VLTC:
Score of crs1 vs cms: 142 - 95 - 641  [0.527] 878
Elo difference: 18.6 +/- 11.9, LOS: 99.9 %, DrawRatio: 73.0 %
SPRT: llr 2.21 (100.4%), lbound -2.2, ubound 2.2 - H1 was accepted
