### PR TITLE
Experiments

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -426,7 +426,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
     // Nullmove pruning with verification like SF does it
     int bestknownscore = (hashscore != NOSCORE ? hashscore : staticeval);
-    if (!isCheckbb && depth >= 2 && bestknownscore >= beta && (ply  >= nullmoveply || ply % 2 != nullmoveside))
+    if (!isCheckbb && depth >= 2 && bestknownscore >= beta && (ply  >= nullmoveply || ply % 2 != nullmoveside) && ph < 255)
     {
         playNullMove();
         int R = 4 + (depth / 6) + (bestknownscore - beta) / 150 + !PVNode * 2;
@@ -590,6 +590,10 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 SDEBUGDO(isDebugPv, pvabortval[ply] = sBeta; pvaborttype[ply] = PVA_MULTICUT;);
                 return sBeta;
             }
+        }
+        else if (ph > 200 && GETCAPTURE(m->code) >= WKNIGHT)
+        {
+            extendMove = 1;
         }
 
         int reduction = 0;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -591,12 +591,10 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 return sBeta;
             }
         }
-#if 0
         else if (ph > 200 && GETCAPTURE(m->code) >= WKNIGHT)
         {
             extendMove = 1;
         }
-#endif
         int reduction = 0;
 
         // Late move reduction

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -591,11 +591,12 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 return sBeta;
             }
         }
+#if 0
         else if (ph > 200 && GETCAPTURE(m->code) >= WKNIGHT)
         {
             extendMove = 1;
         }
-
+#endif
         int reduction = 0;
 
         // Late move reduction


### PR DESCRIPTION
STC:
ELO   | 4.19 +- 3.33 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 19078 W: 4486 L: 4256 D: 10336

LTC:
ELO   | 3.29 +- 2.60 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.05 (-2.94, 2.94) [0.00, 5.00]
Games | N: 24800 W: 4605 L: 4370 D: 15825

Testing eet.epd at 3 seconds: 61/100 vs 56/100

This also solves/improves the bad endgame positions mentioned in DeveloperLog. 