### PR TITLE
Remove unnecessary "struct" keywords

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -380,7 +380,7 @@ static void benchTableFooder(FILE *out, long long totaltime, long long totalnode
 
 static void doBenchmark(int constdepth, string epdfilename, int consttime, int startnum, bool openbench)
 {
-    struct benchmarkstruct benchmark[] =
+    benchmarkstruct benchmark[] =
     {
         {   
             "Startposition",
@@ -481,7 +481,7 @@ static void doBenchmark(int constdepth, string epdfilename, int consttime, int s
     };
 
     long long starttime, endtime;
-    list<struct benchmarkstruct> bmlist;
+    list<benchmarkstruct> bmlist;
 
     ifstream epdfile;
     bool bGetFromEpd = false;
@@ -495,14 +495,14 @@ static void doBenchmark(int constdepth, string epdfilename, int consttime, int s
 
     int i = 0;
     int totalSolved[2] = { 0 };
-    struct benchmarkstruct epdbm;
+    benchmarkstruct epdbm;
     FILE *tableout = openbench ? stdout : stderr;
 
     while (true)
     {
         string avoidmoves = "";
         string bestmoves = "";
-        struct benchmarkstruct *bm;
+        benchmarkstruct *bm;
         if (!bGetFromEpd)
         {
             // standard bench with included positions
@@ -570,7 +570,7 @@ static void doBenchmark(int constdepth, string epdfilename, int consttime, int s
     long long totalnodes = 0;
     benchTableHeader(tableout);
 
-    for (list<struct benchmarkstruct>::iterator bm = bmlist.begin(); bm != bmlist.end(); bm++)
+    for (list<benchmarkstruct>::iterator bm = bmlist.begin(); bm != bmlist.end(); bm++)
     {
         totaltime += bm->time;
         totalnodes += bm->nodes;
@@ -713,8 +713,8 @@ static BOOL writetoengine(HANDLE pipe, const char *s)
 
 static void testengine(string epdfilename, int startnum, string engineprgs, string logfilename, string comparefilename, int maxtime, int flags)
 {
-    struct enginestate es[4];
-    struct enginestate ges;
+    enginestate es[4];
+    enginestate ges;
     string engineprg[4];
     int numEngines = 0;
     string line;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -19,7 +19,7 @@
 #include "RubiChess.h"
 
 #ifdef STATISTICS
-struct statistic statistics;
+statistic statistics;
 #endif
 
 const int deltapruningmargin = 100;

--- a/src/tbprobe.cpp
+++ b/src/tbprobe.cpp
@@ -85,7 +85,7 @@ static uint64 calc_key(int mirror, chessposition *pos)
 // probe_wdl_table and probe_dtz_table require similar adaptations.
 static int probe_wdl_table(int *success, chessposition *pos)
 {
-    struct TBEntry *ptr;
+    TBEntry *ptr;
     uint64 idx;
     uint64 key;
     int i;
@@ -152,7 +152,7 @@ static int probe_wdl_table(int *success, chessposition *pos)
     // pc[i] ^ cmirror, where 1 = white pawn, ..., 14 = black king.
     // Pieces of the same type are guaranteed to be consecutive.
     if (!ptr->has_pawns) {
-        struct TBEntry_piece *entry = (struct TBEntry_piece *)ptr;
+        TBEntry_piece *entry = (TBEntry_piece *)ptr;
         ubyte *pc = entry->pieces[bside];
         for (i = 0; i < entry->num;) {
             U64 bb = pos->piece00[SYZYGY2RUBI_PT(pc[i] ^ cmirror)];
@@ -167,7 +167,7 @@ static int probe_wdl_table(int *success, chessposition *pos)
         res = decompress_pairs(entry->precomp[bside], idx);
     }
     else {
-        struct TBEntry_pawn *entry = (struct TBEntry_pawn *)ptr;
+        TBEntry_pawn *entry = (TBEntry_pawn *)ptr;
         int k = entry->file[0].pieces[0][0] ^ cmirror;
         U64 bb = pos->piece00[SYZYGY2RUBI_PT(k)];
         i = 0;
@@ -198,7 +198,7 @@ static int probe_wdl_table(int *success, chessposition *pos)
 // en passant rights.
 static int probe_dtz_table(int wdl, int *success, chessposition *pos)
 {
-    struct TBEntry *ptr;
+    TBEntry *ptr;
     uint64 idx;
     int i, res;
     int p[TBPIECES];
@@ -210,7 +210,7 @@ static int probe_dtz_table(int wdl, int *success, chessposition *pos)
         for (i = 1; i < DTZ_ENTRIES; i++)
             if (DTZ_table[i].key1 == key || DTZ_table[i].key2 == key) break;
         if (i < DTZ_ENTRIES) {
-            struct DTZTableEntry table_entry = DTZ_table[i];
+            DTZTableEntry table_entry = DTZ_table[i];
             for (; i > 0; i--)
                 DTZ_table[i] = DTZ_table[i - 1];
             DTZ_table[0] = table_entry;
@@ -260,7 +260,7 @@ static int probe_dtz_table(int wdl, int *success, chessposition *pos)
     }
 
     if (!ptr->has_pawns) {
-        struct DTZEntry_piece *entry = (struct DTZEntry_piece *)ptr;
+        DTZEntry_piece *entry = (DTZEntry_piece *)ptr;
         if ((entry->flags & 1) != bside && !entry->symmetric) {
             *success = -1;
             return 0;
@@ -275,7 +275,7 @@ static int probe_dtz_table(int wdl, int *success, chessposition *pos)
                 p[i++] = index;
             }
         }
-        idx = encode_piece((struct TBEntry_piece *)entry, entry->norm, p, entry->factor);
+        idx = encode_piece((TBEntry_piece *)entry, entry->norm, p, entry->factor);
         res = decompress_pairs(entry->precomp, idx);
 
         if (entry->flags & 2)
@@ -285,7 +285,7 @@ static int probe_dtz_table(int wdl, int *success, chessposition *pos)
             res *= 2;
     }
     else {
-        struct DTZEntry_pawn *entry = (struct DTZEntry_pawn *)ptr;
+        DTZEntry_pawn *entry = (DTZEntry_pawn *)ptr;
         int k = entry->file[0].pieces[0] ^ cmirror;
         U64 bb = pos->piece00[SYZYGY2RUBI_PT(k)];
         i = 0;
@@ -295,7 +295,7 @@ static int probe_dtz_table(int wdl, int *success, chessposition *pos)
             index = pullLsb(&bb);
             p[i++] = index ^ mirror;
         }
-        int f = pawn_file((struct TBEntry_pawn *)entry, p);
+        int f = pawn_file((TBEntry_pawn *)entry, p);
         if ((entry->flags[f] & 1) != bside) {
             *success = -1;
             return 0;
@@ -309,7 +309,7 @@ static int probe_dtz_table(int wdl, int *success, chessposition *pos)
                 p[i++] = index ^ mirror;
             }
         }
-        idx = encode_pawn((struct TBEntry_pawn *)entry, entry->file[f].norm, p, entry->file[f].factor);
+        idx = encode_pawn((TBEntry_pawn *)entry, entry->file[f].norm, p, entry->file[f].factor);
         res = decompress_pairs(entry->file[f].precomp, idx);
 
         if (entry->flags[f] & 2)

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -694,7 +694,7 @@ static int getGradientValue(eval *ev, positiontuneset *p, evalparam *e, bool deb
 
 double texel_k = 1.121574;
 
-static double TexelEvalError(struct tuner *tn, double k = texel_k)
+static double TexelEvalError(tuner *tn, double k = texel_k)
 {
     double Ri, Qi;
     double E = 0.0;
@@ -980,7 +980,7 @@ static void getGradsFromFen(string fenfilenames)
 
 
 
-static void copyParams(chessposition *p, struct tuner *tn)
+static void copyParams(chessposition *p, tuner *tn)
 {
     for (int i = 0; i < p->tps.count; i++)
         tn->ev[i] = *p->tps.ev[i];
@@ -988,7 +988,7 @@ static void copyParams(chessposition *p, struct tuner *tn)
 }
 
 
-static void tuneParameter(struct tuner *tn)
+static void tuneParameter(tuner *tn)
 {
     tn->busy = true;
 
@@ -1246,7 +1246,7 @@ void TexelTune(string fenfilenames, bool noqs, bool bOptimizeK, string correlati
     }
 
     tunerpool tpool;
-    tpool.tn = new struct tuner[en.Threads];
+    tpool.tn = new tuner[en.Threads];
     tpool.lowRunning = -1;
     tpool.highRunning = -1;
     tpool.lastImproved = -1;
@@ -1395,14 +1395,14 @@ U64 getTime()
 
 U64 getTime()
 {
-    struct timespec now;
+    timespec now;
     clock_gettime(CLOCK_REALTIME, &now);
     return (U64)(1000000000LL * now.tv_sec + now.tv_nsec);
 }
 
 void Sleep(long x)
 {
-    struct timespec now;
+    timespec now;
     now.tv_sec = 0;
     now.tv_nsec = x * 1000000;
     nanosleep(&now, NULL);


### PR DESCRIPTION
In C++ "struct" before declaring a struct variable is no longer needed and it's really strange to read if sometimes you use them and sometimes you don't. I cleaned this up and removed all struct keywords before variable declarations.