### PR TITLE
smart getBestPossibleCapture

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -936,6 +936,8 @@ template <int Me> void chessposition::updatePins()
         if (ONEORZERO(potentialPinners))
             kingPinned |= potentialPinners;
     }
+    // 'Reset' attack vector to make getBestPossibleCapture work even if evaluation was skipped
+    attackedBy[Me][0] = 0xffffffffffffffff;
 }
 
 
@@ -2214,13 +2216,13 @@ int chessposition::getBestPossibleCapture()
     int you = me ^ S2MMASK;
     int captureval = 0;
 
-    if (piece00[WQUEEN | you])
+    if (piece00[WQUEEN | you] & attackedBy[me][0])
         captureval += materialvalue[QUEEN];
-    else if (piece00[WROOK | you])
+    else if (piece00[WROOK | you] & attackedBy[me][0])
         captureval += materialvalue[ROOK];
-    else if (piece00[WKNIGHT | you] || piece00[WBISHOP | you])
+    else if ((piece00[WKNIGHT | you] | piece00[WBISHOP | you]) & attackedBy[me][0])
         captureval += materialvalue[KNIGHT];
-    else if (piece00[WPAWN | you])
+    else if (piece00[WPAWN | you] & attackedBy[me][0])
         captureval += materialvalue[PAWN];
 
     // promotion

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -2215,14 +2215,15 @@ int chessposition::getBestPossibleCapture()
     int me = state & S2MMASK;
     int you = me ^ S2MMASK;
     int captureval = 0;
+    const U64 msk = attackedBy[me][0];
 
-    if (piece00[WQUEEN | you] & attackedBy[me][0])
+    if (piece00[WQUEEN | you] & msk)
         captureval += materialvalue[QUEEN];
-    else if (piece00[WROOK | you] & attackedBy[me][0])
+    else if (piece00[WROOK | you] & msk)
         captureval += materialvalue[ROOK];
-    else if ((piece00[WKNIGHT | you] | piece00[WBISHOP | you]) & attackedBy[me][0])
+    else if ((piece00[WKNIGHT | you] | piece00[WBISHOP | you]) & msk)
         captureval += materialvalue[KNIGHT];
-    else if (piece00[WPAWN | you] & attackedBy[me][0])
+    else if (piece00[WPAWN | you] & msk)
         captureval += materialvalue[PAWN];
 
     // promotion

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -477,15 +477,13 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     // ProbCut
     if (!PVNode && depth >= 5 && abs(beta) < SCOREWHITEWINS)
     {
-        int rbeta = min(SCOREWHITEWINS, beta + 100);
+        int rbeta = min(SCOREWHITEWINS, beta + 100  - 20 * positionImproved);
         chessmovelist *movelist = new chessmovelist;
         movelist->length = CreateMovelist<TACTICAL>(this, &movelist->move[0]);
 
         for (int i = 0; i < movelist->length; i++)
         {
             chessmove* m = &movelist->move[i];
-            if ((m->code & 0xffff) == excludeMove)
-                continue;
 
             if (!see(m->code, rbeta - staticeval))
                 continue;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -476,7 +476,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
     // ProbCut
     const int probcutmargin = 100;
-    if (!PVNode && depth >= 5 && abs(beta) < SCOREWHITEWINS && staticeval + getBestPossibleCapture() >= beta + probcutmargin)
+    if (!PVNode && depth >= 5 && abs(beta) < SCOREWHITEWINS)
     {
         int rbeta = min(SCOREWHITEWINS, beta + probcutmargin);
         chessmovelist *movelist = new chessmovelist;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -483,14 +483,18 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
         for (int i = 0; i < movelist->length; i++)
         {
-            if (!see(movelist->move[i].code, rbeta - staticeval))
+            chessmove* m = &movelist->move[i];
+            if ((m->code & 0xffff) == excludeMove)
                 continue;
 
-            if (playMove(&movelist->move[i]))
+            if (!see(m->code, rbeta - staticeval))
+                continue;
+
+            if (playMove(m))
             {
                 int probcutscore = -alphabeta(-rbeta, -rbeta + 1, depth - 4);
 
-                unplayMove(&movelist->move[i]);
+                unplayMove(m);
 
                 if (probcutscore >= rbeta)
                 {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -477,7 +477,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     // ProbCut
     if (!PVNode && depth >= 5 && abs(beta) < SCOREWHITEWINS)
     {
-        int rbeta = min(SCOREWHITEWINS, beta + 100  - 20 * positionImproved);
+        int rbeta = min(SCOREWHITEWINS, beta + 120);
         chessmovelist *movelist = new chessmovelist;
         movelist->length = CreateMovelist<TACTICAL>(this, &movelist->move[0]);
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -475,9 +475,10 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     }
 
     // ProbCut
-    if (!PVNode && depth >= 5 && abs(beta) < SCOREWHITEWINS)
+    const int probcutmargin = 100;
+    if (!PVNode && depth >= 5 && abs(beta) < SCOREWHITEWINS && staticeval + getBestPossibleCapture() >= beta + probcutmargin)
     {
-        int rbeta = min(SCOREWHITEWINS, beta + 120);
+        int rbeta = min(SCOREWHITEWINS, beta + probcutmargin);
         chessmovelist *movelist = new chessmovelist;
         movelist->length = CreateMovelist<TACTICAL>(this, &movelist->move[0]);
 


### PR DESCRIPTION
This helps deltapruning a lot (raises from 1,09% to  6,68%).

STC:
ELO   | 3.51 +- 2.75 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 26416 W: 5823 L: 5556 D: 15037

LTC:
ELO   | 4.54 +- 3.11 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 4.00]
Games | N: 15454 W: 2603 L: 2401 D: 10450

