### PR TITLE
history extension

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1479,7 +1479,9 @@ struct statistic {
     S64 red_pv;                 // total reduction by pv nodes
     S64 red_correction;         // total reduction correction by over-/underflow
 
-    U64 extend_singular;        // total extended moves
+    U64 extend_singular;        // total singular extensions
+    U64 extend_endgame;        // total endgame extensions
+    U64 extend_history;        // total history extensions
 };
 
 extern struct statistic statistics;

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1416,7 +1416,7 @@ public:
     int depth;
     int numofthreads;
     int lastCompleteDepth;
-
+    // adjust padding to align searchthread at 64 bytes
     uint8_t padding[16];
 
     searchthread *searchthreads;

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1177,6 +1177,9 @@ public:
     int16_t history[2][64][64];
     int16_t counterhistory[14][64][14 * 64];
     uint32_t countermove[14][64];
+    int he_threshold;
+    U64 he_yes;
+    U64 he_all;
     Materialhash mtrlhsh;
     Pawnhash pwnhsh;
 
@@ -1414,7 +1417,7 @@ public:
     int numofthreads;
     int lastCompleteDepth;
 
-    uint8_t padding[40];
+    uint8_t padding[16];
 
     searchthread *searchthreads;
 };

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -2482,6 +2482,7 @@ void engine::allocThreads()
     memset((void*)sthread, 0, size);
     for (int i = 0; i < Threads; i++)
     {
+        //printf("%d\n", (U64)&sthread[i] % 64);
         sthread[i].index = i;
         sthread[i].searchthreads = sthread;
         sthread[i].numofthreads = Threads;
@@ -2505,8 +2506,8 @@ void engine::prepareThreads()
         pos->bestmovescore[0] = NOSCORE;
         pos->bestmove.code = 0;
         pos->nodes = 0;
-        sthread[i].pos.nullmoveply = 0;
-        sthread[i].pos.nullmoveside = 0;
+        pos->nullmoveply = 0;
+        pos->nullmoveside = 0;
     }
 }
 
@@ -2514,9 +2515,13 @@ void engine::resetStats()
 {
     for (int i = 0; i < Threads; i++)
     {
-        memset(sthread[i].pos.history, 0, sizeof(chessposition::history));
-        memset(sthread[i].pos.counterhistory, 0, sizeof(chessposition::counterhistory));
-        memset(sthread[i].pos.countermove, 0, sizeof(chessposition::countermove));
+        chessposition* pos = &sthread[i].pos;
+        memset(pos->history, 0, sizeof(chessposition::history));
+        memset(pos->counterhistory, 0, sizeof(chessposition::counterhistory));
+        memset(pos->countermove, 0, sizeof(chessposition::countermove));
+        pos->he_yes = 0ULL;
+        pos->he_all = 0ULL;
+        pos->he_threshold = 8100;
     }
 }
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -2477,12 +2477,12 @@ void engine::allocThreads()
         return;
 
     size_t size = Threads * sizeof(searchthread);
+    myassert(size % 64 == 0, nullptr, 1, size % 64);
 
     sthread = (searchthread*) allocalign64(size);
     memset((void*)sthread, 0, size);
     for (int i = 0; i < Threads; i++)
     {
-        //printf("%d\n", (U64)&sthread[i] % 64);
         sthread[i].index = i;
         sthread[i].searchthreads = sthread;
         sthread[i].numofthreads = Threads;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -590,6 +590,8 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         int pc = GETPIECE(m->code);
         int to = GETCORRECTTO(m->code);
 
+        const int goodContinuationHistory = 8100;
+
         // Singular extension
         if ((m->code & 0xffff) == hashmovecode
             && depth > 7
@@ -619,10 +621,12 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         // Extend captures that lead into endgame
         else if (ph > 200 && GETCAPTURE(m->code) >= WKNIGHT)
         {
+            STATISTICSINC(extend_endgame);
             extendMove = 1;
         }
-        else if(!ISTACTICAL(m->code) && ms.cmptr[0] && ms.cmptr[1] && ms.cmptr[0][pc * 64 + to] > 10000 && ms.cmptr[1][pc * 64 + to] > 10000)
+        else if(!ISTACTICAL(m->code) && ms.cmptr[0] && ms.cmptr[1] && ms.cmptr[0][pc * 64 + to] > goodContinuationHistory && ms.cmptr[1][pc * 64 + to] > goodContinuationHistory)
         {
+            STATISTICSINC(extend_history);
             extendMove = 1;
         }
 
@@ -1635,7 +1639,9 @@ void search_statistics()
     printf("(ST) Reduct.  %12lld   lmr[0]: %4.2f   lmr[1]: %4.2f   lmr: %4.2f   hist: %4.2f   pv: %4.2f   corr: %4.2f   total: %4.2f\n", red_n, f10, f11, f1, f2, f3, f4, f5);
 
     f0 = 100.0 * statistics.extend_singular / (double)n;
-    printf("(ST) Extensions: %%singular: %7.4f\n", f0);
+    f1 = 100.0 * statistics.extend_endgame / (double)n;
+    f2 = 100.0 * statistics.extend_history / (double)n;
+    printf("(ST) Extensions: %%singular: %7.4f   %%endgame: %7.4f   %%history: %7.4f\n", f0, f1, f2);
     printf("(ST)==================================================================================================================================================\n");
 }
 #endif

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -587,6 +587,8 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
         int stats = getHistory(m->code, ms.cmptr);
         int extendMove = 0;
+        int pc = GETPIECE(m->code);
+        int to = GETCORRECTTO(m->code);
 
         // Singular extension
         if ((m->code & 0xffff) == hashmovecode
@@ -619,6 +621,10 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         {
             extendMove = 1;
         }
+        else if(!ISTACTICAL(m->code) && ms.cmptr[0] && ms.cmptr[1] && ms.cmptr[0][pc * 64 + to] > 10000 && ms.cmptr[1][pc * 64 + to] > 10000)
+        {
+            extendMove = 1;
+        }
 
         // Late move reduction
         int reduction = 0;
@@ -648,8 +654,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             STATISTICSADD(red_total, reduction);
         }
 
-        int pc = GETPIECE(m->code);
-        int to = GETCORRECTTO(m->code);
         effectiveDepth = depth + extendall - reduction + extendMove;
 
         // Prune moves with bad counter move history

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -590,8 +590,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         int pc = GETPIECE(m->code);
         int to = GETCORRECTTO(m->code);
 
-        //int goodContinuationHistory = 8100;
-
         // Singular extension
         if ((m->code & 0xffff) == hashmovecode
             && depth > 7
@@ -634,22 +632,17 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
             if ((++he_all & 0x3fffff) == 0)
             {
-                //printf("info string he-ration: %7.4f%%  ", 100.0 * he_yes / (double)he_all);
+                // adjust history extension threshold
                 if (he_all / 512 < he_yes)
                 {
-                    // > 0.1953% ==> increase threshold
+                    // 1/512 ~ extension ratio > 0.1953% ==> increase threshold
                     he_threshold = he_threshold * 257 / 256;
                     he_all = he_yes = 0ULL;
-                    //printf(" too many he; new he_threshold: %d\n", he_threshold);
                 } else if (he_all / 32768 > he_yes)
                 {
-                    // > 0.0030% ==> decrease threshold
+                    // 1/32768 ~ extension ratio < 0.0030% ==> decrease threshold
                     he_threshold = he_threshold * 255 / 256;
                     he_all = he_yes = 0ULL;
-                    //printf(" too few he; new he_threshold: %d\n", he_threshold);
-                }
-                else {
-                    //printf(" he okay; he_threshold: %d\n", he_threshold);
                 }
             }
         }


### PR DESCRIPTION
Tests with static extension threshold
20+0.2:
ELO   | 9.97 +- 5.72 (95%)
SPRT  | 20.0+0.2s Threads=1 Hash=16MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5264 W: 1057 L: 906 D: 3301

60+0.6:
ELO   | 3.29 +- 2.60 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 21304 W: 3426 L: 3224 D: 14654

Test with dynamic extension to avoid stuck search:
60+0.6:
ELO   | 3.42 +- 2.65 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 20608 W: 3321 L: 3118 D: 14169
