### PR TITLE
Lets see if this 'more reduction after fail high in root' works in Rubi.

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1211,7 +1211,7 @@ public:
     void getScaling(Materialhashentry *mhentry);
     int getComplexity(int eval, pawnhashentry *phentry, Materialhashentry *mhentry);
 
-    template <RootsearchType RT> int rootsearch(int alpha, int beta, int depth);
+    template <RootsearchType RT> int rootsearch(int alpha, int beta, int depth, int inWindowLast);
     int alphabeta(int alpha, int beta, int depth);
     int getQuiescence(int alpha, int beta, int depth);
     void updateHistory(uint32_t code, int16_t **cmptr, int value);


### PR DESCRIPTION
STC:
ELO   | 5.18 +- 3.90 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 13280 W: 3005 L: 2807 D: 7468

LTC:
ELO   | 3.74 +- 2.89 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 17648 W: 2910 L: 2720 D: 12018
