### PR TITLE
More penalty for unopposed isolated pawns.

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -371,7 +371,10 @@ struct evalparamset {
         {  VALUE(   0,   0), VALUE( -43,   9), VALUE( -15,  17), VALUE(   0,  31), VALUE(  33,  31), VALUE(  71,  95), VALUE(   0,   0), VALUE(   0,   0)  }
     };
     eval eAttackingpawnbonus[8] = {  VALUE(   0,   0), VALUE( -32,  12), VALUE( -22, -12), VALUE(  -6,  -6), VALUE( -12,  -6), VALUE( -13,  -2), VALUE(   0,   0), VALUE(   0,   0)  };
-    eval eIsolatedpawnpenalty[8] = {  VALUE( -10,  -5), VALUE( -10,  -6), VALUE( -16, -12), VALUE( -22, -12), VALUE( -26, -12), VALUE( -13, -11), VALUE(  -8, -10), VALUE( -15,  -3)  };
+    eval eIsolatedpawnpenalty[2][8] = {
+        {  VALUE( -15,  -1), VALUE( -19,   6), VALUE( -23, -10), VALUE( -28, -14), VALUE( -34, -12), VALUE( -22, -13), VALUE( -21,   1), VALUE( -20,   6)  },
+        {  VALUE( -10,  -5), VALUE( -11,  -7), VALUE( -15, -10), VALUE( -13,  -7), VALUE( -17,  -3), VALUE(  -7, -12), VALUE(  -4, -15), VALUE( -14,  -4)  }
+    };
     eval eDoublepawnpenalty =  VALUE( -11, -23);
     eval eConnectedbonus[6][6] = {
         {  VALUE(   0,   0), VALUE(  10,  -2), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0), VALUE(   0,   0)  },

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -180,9 +180,10 @@ void registerallevals(chessposition *pos)
     tuneIt = false;
     for (i = 0; i < 8; i++)
         registertuner(pos, &eps.eAttackingpawnbonus[i], "eAttackingpawnbonus", i, 8, 0, 0, tuneIt && (i > 0 && i < 7));
-    tuneIt = false;
-    for (i = 0; i < 8; i++)
-        registertuner(pos, &eps.eIsolatedpawnpenalty[i], "eIsolatedpawnpenalty", i, 8, 0, 0, tuneIt);
+    tuneIt = true;
+    for (i = 0; i < 2; i++)
+        for (j = 0; j < 8; j++)
+            registertuner(pos, &eps.eIsolatedpawnpenalty[i][j], "eIsolatedpawnpenalty", j, 8, i, 2, tuneIt);
     tuneIt = false;
     registertuner(pos, &eps.eDoublepawnpenalty, "eDoublepawnpenalty", 0, 0, 0, 0, tuneIt);
     tuneIt = false;
@@ -210,7 +211,7 @@ void registerallevals(chessposition *pos)
     tuneIt = false;
     registertuner(pos, &eps.eRookon7thbonus, "eRookon7thbonus", 0, 0, 0, 0, tuneIt);
 
-    tuneIt = true;
+    tuneIt = false;
     registertuner(pos, &eps.eQueenattackedbysliderpenalty, "eQueenattackedbysliderpenalty", 0, 0, 0, 0, tuneIt);
 
     tuneIt = false;
@@ -392,6 +393,7 @@ void chessposition::getPawnAndKingEval(pawnhashentry *entryptr)
         entryptr->semiopen[Me] &= (int)(~BITSET(FILE(index)));
 
         U64 yourStoppers = passedPawnMask[index][Me] & yourPawns;
+        U64 yourOpponents = yourStoppers & fileMask[index];
         if (!yourStoppers)
         {
             // passed pawn
@@ -426,8 +428,9 @@ void chessposition::getPawnAndKingEval(pawnhashentry *entryptr)
         {
             // isolated pawn penalty per file
             int f = FILE(index);
-            entryptr->value += EVAL(eps.eIsolatedpawnpenalty[f], S2MSIGN(Me));
-            if (bTrace) te.pawns[Me] += EVAL(eps.eIsolatedpawnpenalty[f], S2MSIGN(Me));
+            bool opposed = (bool)yourOpponents;
+            entryptr->value += EVAL(eps.eIsolatedpawnpenalty[opposed][f], S2MSIGN(Me));
+            if (bTrace) te.pawns[Me] += EVAL(eps.eIsolatedpawnpenalty[opposed][f], S2MSIGN(Me));
         }
         else
         {


### PR DESCRIPTION
STC:
ELO   | 5.94 +- 4.36 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 11056 W: 2605 L: 2416 D: 6035

LTC:
ELO   | 8.23 +- 4.95 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 3.01 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6416 W: 1166 L: 1014 D: 4236