### PR TITLE
Test if the probcut capture move is good enough before doing a reduce…

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -498,7 +498,9 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
             if (playMove(cm))
             {
-                int probcutscore = -alphabeta(-rbeta, -rbeta + 1, depth - 4);
+                int probcutscore = -getQuiescence(-rbeta, -rbeta + 1, 0);
+                if (probcutscore >= rbeta)
+                    probcutscore = -alphabeta(-rbeta, -rbeta + 1, depth - 4);
 
                 unplayMove(cm);
 


### PR DESCRIPTION
…d search.

STC:
ELO   | 6.64 +- 4.66 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 9472 W: 2193 L: 2012 D: 5267

LTC:
ELO   | 13.23 +- 6.50 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3600 W: 661 L: 524 D: 2415
