### PR TITLE
Fix scaling to use the endgame value instead of the 32bit score which…

### DIFF
--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -829,7 +829,7 @@ int chessposition::getEval()
 
     int totalEval = psqval + pawnEval + generalEval + piecesEval + lateEval;
 
-    int sideToScale = totalEval > SCOREDRAW ? WHITE : BLACK;
+    int sideToScale = GETEGVAL(totalEval) > SCOREDRAW ? WHITE : BLACK;
 
     sc = pe.mhentry->scale[sideToScale];
     if (!bTrace && sc == SCALE_DRAW)


### PR DESCRIPTION
… is infact the midgame value repsecting the operation "> 0"

STC:
ELO   | 3.44 +- 2.71 (95%)
SPRT  | 10.0+0.1s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 27168 W: 5998 L: 5729 D: 15441

Examples of positions that are fixed by this patch:
8/6p1/5pNp/p5k1/8/8/K7/8 w - - 2 71
8/7k/8/5K2/2P2P2/b5PP/8/8 b - - 0 45
7k/8/8/1n6/4PP1P/8/6KP/8 b - - 2 54

