### PR TITLE
Nnuespeed

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1400,7 +1400,7 @@ public:
 #ifdef NNUE
     void HalfkpAppendActiveIndices(int c, NnueIndexList *active);
     void AppendActiveIndices(NnueIndexList active[2]);
-    void HalfkpAppendChangedIndices(int c, NnueIndexList *add, NnueIndexList *remove);
+    void HalfkpAppendChangedIndices(int c, DirtyPiece* dp, NnueIndexList *add, NnueIndexList *remove);
     void AppendChangedIndices(NnueIndexList add[2], NnueIndexList remove[2], bool reset[2]);
     void RefreshAccumulator();
     bool UpdateAccumulator();

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -723,8 +723,7 @@ class NnueAccumulator
 {
 public:
     alignas(64) int16_t accumulation[2][256];
-    int score;
-    int computationState;
+    bool computationState;
 };
 
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -2603,6 +2603,7 @@ void engine::prepareThreads()
         pos->nodes = 0;
         pos->nullmoveply = 0;
         pos->nullmoveside = 0;
+        pos->accumulator->computationState = false;
     }
 }
 

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -715,7 +715,7 @@ void chessposition::playNullMove()
     if (accumulator[mstop - 1].computationState)
         accumulator[mstop] = accumulator[mstop - 1];
     else
-        accumulator[mstop].computationState = 0;
+        accumulator[mstop].computationState = false;
 #endif
 }
 
@@ -1539,7 +1539,7 @@ bool chessposition::playMove(chessmove *cm)
 #ifdef NNUE
     DirtyPiece* dp = &dirtypiece[mstop + 1];
     dp->dirtyNum = 0;
-    accumulator[mstop + 1].computationState = 0;
+    accumulator[mstop + 1].computationState = false;
 #endif
 
     halfmovescounter++;

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -716,7 +716,6 @@ void chessposition::playNullMove()
         accumulator[mstop] = accumulator[mstop - 1];
     else
         accumulator[mstop].computationState = 0;
-
 #endif
 }
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -222,7 +222,7 @@ void chessposition::RefreshAccumulator()
         }
     }
 
-    ac->computationState = 1;
+    ac->computationState = true;
 }
 
 // Test if we can update the accumulator from the previous position
@@ -243,6 +243,8 @@ bool chessposition::UpdateAccumulator()
         prevac = &accumulator[mstop - 2];
         if (!prevac->computationState)
             return false;
+        else
+            printf("");
     }
 
     NnueIndexList removedIndices[2], addedIndices[2];
@@ -330,7 +332,7 @@ bool chessposition::UpdateAccumulator()
         }
     }
 
-    ac->computationState = 1;
+    ac->computationState = true;
     return true;
 }
 

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -243,8 +243,6 @@ bool chessposition::UpdateAccumulator()
         prevac = &accumulator[mstop - 2];
         if (!prevac->computationState)
             return false;
-        else
-            printf("");
     }
 
     NnueIndexList removedIndices[2], addedIndices[2];


### PR DESCRIPTION
STC:
Score of cnn1 vs cms: 894 - 799 - 3119  [0.510] 4812
Elo difference: 6.9 +/- 5.8, LOS: 99.0 %, DrawRatio: 64.8 %
SPRT: llr 2.21 (100.4%), lbound -2.2, ubound 2.2 - H1 was accepted
Finished match
