### PR TITLE
Nocastlepenalty

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -429,6 +429,7 @@ struct evalparamset {
            VALUE(  20, 253), VALUE(  21, 256), VALUE(  18, 263), VALUE(  13, 270), VALUE(  45, 244), VALUE(  67, 233), VALUE(  72, 241), VALUE(  80, 230),
            VALUE(  69, 264), VALUE( 108, 231), VALUE( 107, 230), VALUE( 114, 198)  }
     };
+    eval eNocastlepenalty = VALUE(-10, 0);
     eval eRookon7thbonus =  VALUE(  -1,  22);
     eval eRookonkingarea =  VALUE(   7,  -6);
     eval eBishoponkingarea =  VALUE(  10,   2);
@@ -915,6 +916,7 @@ extern transposition tp;
 #define CASTLEMASK  0x1e
 #define GETCASTLEFILE(s,i) (((s) >> (i * 4 + 8)) & 0x7)
 #define SETCASTLEFILE(f,i) (((f) << (i * 4 + 8)) | (WQCMASK << i))
+#define GETCASTLERIGHTS(c,s) ((c) ? (s) & (BQCMASK | BKCMASK) : (s) & (WQCMASK | WKCMASK)) 
 
 #define WQC 1
 #define WKC 2

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -429,7 +429,7 @@ struct evalparamset {
            VALUE(  20, 253), VALUE(  21, 256), VALUE(  18, 263), VALUE(  13, 270), VALUE(  45, 244), VALUE(  67, 233), VALUE(  72, 241), VALUE(  80, 230),
            VALUE(  69, 264), VALUE( 108, 231), VALUE( 107, 230), VALUE( 114, 198)  }
     };
-    eval eNocastlepenalty = VALUE(-10, 0);
+    eval eNocastlepenalty = VALUE(-5, 5);
     eval eRookon7thbonus =  VALUE(  -1,  22);
     eval eRookonkingarea =  VALUE(   7,  -6);
     eval eBishoponkingarea =  VALUE(  10,   2);

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -161,6 +161,9 @@ void registerallevals(chessposition *pos)
             registertuner(pos, &eps.eMobilitybonus[i][j], "eMobilitybonus", j, 28, i, 4, tuneIt && (j < maxmobility[i]));
 
     tuneIt = false;
+    registertuner(pos, &eps.eNocastlepenalty, "eNocastlepenalty", 0, 0, 0, 0, tuneIt);
+
+    tuneIt = false;
     registertuner(pos, &eps.eRookon7thbonus, "eRookon7thbonus", 0, 0, 0, 0, tuneIt);
 
     tuneIt = true;
@@ -504,9 +507,16 @@ int chessposition::getPieceEval(positioneval *pe)
             attack = ROOKATTACKS(xrayrookoccupied, index);
 
             // extrabonus for rook on (semi-)open file  
-            if (Pt == ROOK && (pe->phentry->semiopen[Me] & BITSET(FILE(index)))) {
-                result += EVAL(eps.eSlideronfreefilebonus[bool(pe->phentry->semiopen[You] & BITSET(FILE(index)))], S2MSIGN(Me));
-                if (bTrace) te.rooks[Me] += EVAL(eps.eSlideronfreefilebonus[bool(pe->phentry->semiopen[You] & BITSET(FILE(index)))], S2MSIGN(Me));
+            if (Pt == ROOK) {
+                if (pe->phentry->semiopen[Me] & BITSET(FILE(index))) {
+                    result += EVAL(eps.eSlideronfreefilebonus[bool(pe->phentry->semiopen[You] & BITSET(FILE(index)))], S2MSIGN(Me));
+                    if (bTrace) te.rooks[Me] += EVAL(eps.eSlideronfreefilebonus[bool(pe->phentry->semiopen[You] & BITSET(FILE(index)))], S2MSIGN(Me));
+                }
+                else if (!GETCASTLERIGHTS(Me, state))
+                {
+                    result += EVAL(eps.eNocastlepenalty, S2MSIGN(Me));
+                    if (bTrace) te.rooks[Me] += EVAL(eps.eNocastlepenalty, S2MSIGN(Me));
+                }
             }
 
             // extrabonus for rook targeting the kingdanger area

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -160,13 +160,13 @@ void registerallevals(chessposition *pos)
         for (j = 0; j < 28; j++)
             registertuner(pos, &eps.eMobilitybonus[i][j], "eMobilitybonus", j, 28, i, 4, tuneIt && (j < maxmobility[i]));
 
-    tuneIt = false;
+    tuneIt = true;
     registertuner(pos, &eps.eNocastlepenalty, "eNocastlepenalty", 0, 0, 0, 0, tuneIt);
 
     tuneIt = false;
     registertuner(pos, &eps.eRookon7thbonus, "eRookon7thbonus", 0, 0, 0, 0, tuneIt);
 
-    tuneIt = true;
+    tuneIt = false;
     registertuner(pos, &eps.eRookonkingarea, "eRookonkingarea", 0, 0, 0, 0, tuneIt);
     registertuner(pos, &eps.eBishoponkingarea, "eBishoponkingarea", 0, 0, 0, 0, tuneIt);
 
@@ -177,7 +177,7 @@ void registerallevals(chessposition *pos)
     for (i = 0; i < 6; i++)
         registertuner(pos, &eps.eMinorbehindpawn[i], "eMinorbehindpawn", i, 6, 0, 0, tuneIt);
 
-    tuneIt = true;
+    tuneIt = false;
     for (i = 0; i < 2; i++)
         registertuner(pos, &eps.eSlideronfreefilebonus[i], "eSlideronfreefilebonus", i, 2, 0, 0, tuneIt);
 


### PR DESCRIPTION
STC:
ELO   | 2.66 +- 2.08 (95%)
SPRT  | 15.0+0.15s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 43168 W: 8849 L: 8519 D: 25800

LTC:
ELO   | 2.17 +- 1.70 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
Games | N: 50656 W: 8220 L: 7903 D: 34533

STC for FRC:
ELO   | 6.43 +- 4.57 (95%)
SPRT  | 15.0+0.15s Threads=1 Hash=8MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10480 W: 2572 L: 2378 D: 5530

