### PR TITLE
Mixedeval

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -613,6 +613,8 @@ void GetStackWalk(chessposition *pos, const char* message, const char* _File, in
 //
 #define NNUEDEFAULTSTR TOSTRING(NNUEDEFAULT)
 
+const int NnuePsqThreshold = 300;
+
 enum NnueType { NnueDisabled = 0, NnueRotate, NnueFlip };
 #define NNUEFILEVERSIONROTATE     0x7AF32F16u
 #define NNUEFILEVERSIONFLIP       0x7AF32F17u

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -744,7 +744,7 @@ int chessposition::getEval()
 
     int score;
 #ifdef NNUE
-    if (NnueReady)
+    if (NnueReady && abs(GETEGVAL(psqval)) < 400)
     {
         if (NnueReady == NnueRotate)
             score = NnueGetEval<NnueRotate>() + eps.eTempo;

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -744,7 +744,7 @@ int chessposition::getEval()
 
     int score;
 #ifdef NNUE
-    if (NnueReady && abs(GETEGVAL(psqval)) < 400)
+    if (NnueReady && abs(GETEGVAL(psqval)) < NnuePsqThreshold)
     {
         if (NnueReady == NnueRotate)
             score = NnueGetEval<NnueRotate>() + eps.eTempo;


### PR DESCRIPTION
Tested this version (< 300, cme2) and another (< 400, cme1).
```
cme1 (<400)
STC:
Score of cme1 vs cms: 560 - 471 - 1105  [0.521] 2136
Elo difference: 14.5 +/- 10.2, LOS: 99.7 %, DrawRatio: 51.7 %
SPRT: llr 2.2 (100.2%), lbound -2.2, ubound 2.2 - H1 was accepted

LTC:
Score of cme1 vs cms: 417 - 344 - 1215  [0.518] 1976
Elo difference: 12.8 +/- 9.5, LOS: 99.6 %, DrawRatio: 61.5 %
SPRT: llr 2.2 (100.3%), lbound -2.2, ubound 2.2 - H1 was accepted

cme2 (<300)
STC:
Score of cme2 vs cme1: 812 - 705 - 1783  [0.516] 3300
Elo difference: 11.3 +/- 8.0, LOS: 99.7 %, DrawRatio: 54.0 %
SPRT: llr 2.21 (100.5%), lbound -2.2, ubound 2.2 - H1 was accepted

Score of cme2 vs cms: 263 - 169 - 485  [0.551] 917
Elo difference: 35.7 +/- 15.4, LOS: 100.0 %, DrawRatio: 52.9 %
SPRT: llr 2.21 (100.4%), lbound -2.2, ubound 2.2 - H1 was accepted

cme3 (<200)
Score of cme3 vs cme2: 1689 - 1734 - 4058  [0.497] 7481
Elo difference: -2.1 +/- 5.3, LOS: 22.1 %, DrawRatio: 54.2 %
SPRT: llr -2.22 (-100.9%), lbound -2.2, ubound 2.2 - H0 was accepted

LTC-1000:
Score of cme2 vs cms: 202 - 174 - 624  [0.514] 1000
Elo difference: 9.7 +/- 13.2, LOS: 92.6 %, DrawRatio: 62.4 %
Score of cme2 vs cms: 195 - 162 - 643  [0.516] 1000
Elo difference: 11.5 +/- 12.8, LOS: 96.0 %, DrawRatio: 64.3 %

Score of cme2 vs cme1: 217 - 162 - 621  [0.527] 1000
Elo difference: 19.1 +/- 13.2, LOS: 99.8 %, DrawRatio: 62.1 %

Score of cme1 vs cms: 218 - 177 - 605  [0.520] 1000
Elo difference: 14.3 +/- 13.5, LOS: 98.0 %, DrawRatio: 60.5 %

Rank Name                          Elo     +/-   Games   Score   Draws
   1 cme2                            7       9    2000   51.0%   61.3%
   2 cme1                            2       9    2000   50.2%   61.4%
   3 cms                            -9       9    2000   48.7%   62.5%
```