### PR TITLE
Qsearch

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1722,6 +1722,7 @@ int root_probe_wdl(chessposition *pos);
 //
 #ifdef STATISTICS
 struct statistic {
+    int qs_mindepth;
     U64 qs_n[2];                // total calls to qs split into no check / check
     U64 qs_tt;                  // qs hits tt
     U64 qs_pat;                 // qs returns with pat score

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -994,9 +994,7 @@ void chessposition::print(ostream* os)
     *os << "Repetitions: " + to_string(testRepetiton()) + "\n";
     *os << "Phase: " + to_string(phase()) + "\n";
     *os << "Pseudo-legal Moves: " + pseudolegalmoves.toStringWithValue() + "\n";
-#if defined(STACKDEBUG) || defined(SDEBUG)
     *os << "Moves in current search: " + movesOnStack() + "\n";
-#endif
     *os << "mstop: " + to_string(mstop) + "\n";
     *os << "Ply: " + to_string(ply) + "\n";
     *os << "rootheight: " + to_string(rootheight) + "\n";
@@ -1006,7 +1004,6 @@ void chessposition::print(ostream* os)
 }
 
 
-#if defined(STACKDEBUG) || defined(SDEBUG)
 string chessposition::movesOnStack()
 {
     string s = "";
@@ -1018,7 +1015,6 @@ string chessposition::movesOnStack()
     }
     return s;
 }
-#endif
 
 
 string chessposition::toFen()

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -566,7 +566,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     if (!isCheckbb && depth >= sps.nmmindepth && bestknownscore >= beta && (ply  >= nullmoveply || ply % 2 != nullmoveside) && ph < 255)
     {
         playNullMove();
-        int nmreduction = sps.nmmredbase + (depth / sps.nmmreddepthratio) + (bestknownscore - beta) / sps.nmmredevalratio + !PVNode * sps.nmmredpvfactor;
+        int nmreduction = min(depth, sps.nmmredbase + (depth / sps.nmmreddepthratio) + (bestknownscore - beta) / sps.nmmredevalratio + !PVNode * sps.nmmredpvfactor);
 
         score = -alphabeta<Pt>(-beta, -beta + 1, depth - nmreduction);
         unplayNullMove();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -282,7 +282,7 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         if (staticeval >= beta)
         {
             STATISTICSINC(qs_pat);
-            tp.addHash(hash, staticeval, staticeval, HASHBETA, 0, 0);
+            tp.addHash(hash, staticeval, staticeval, HASHBETA, 0, hashmovecode);
 
             return staticeval;
         }
@@ -300,7 +300,7 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
         if (Pt == Prune && bestExpectableScore < alpha)
         {
             STATISTICSINC(qs_delta);
-            tp.addHash(hash, bestExpectableScore, staticeval, HASHALPHA, 0, 0);
+            tp.addHash(hash, bestExpectableScore, staticeval, HASHALPHA, 0, hashmovecode);
             return staticeval;
         }
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -251,6 +251,7 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
 #endif
 
     STATISTICSINC(qs_n[myIsCheck]);
+    STATISTICSDO(if (depth < statistics.qs_mindepth) statistics.qs_mindepth = depth);
 
     int hashscore = NOSCORE;
     uint16_t hashmovecode = 0;
@@ -429,7 +430,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             seldepth = ply + 1;
 
         STATISTICSINC(ab_qs);
-        return getQuiescence<Pt>(alpha, beta, depth);
+        return getQuiescence<Pt>(alpha, beta, 0);
     }
 
     // Maximum depth
@@ -534,11 +535,11 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             int qscore;
             if (depth == 1 && ralpha < alpha)
             {
-                qscore = getQuiescence<Pt>(alpha, beta, depth);
+                qscore = getQuiescence<Pt>(alpha, beta, 0);
                 SDEBUGDO(isDebugPv, pvabortval[ply] = qscore; pvaborttype[ply] = PVA_RAZORPRUNED;);
                 return qscore;
             }
-            qscore = getQuiescence<Pt>(ralpha, ralpha + 1, depth);
+            qscore = getQuiescence<Pt>(ralpha, ralpha + 1, 0);
             if (qscore <= ralpha)
             {
                 SDEBUGDO(isDebugPv, pvabortval[ply] = qscore; pvaborttype[ply] = PVA_RAZORPRUNED;);
@@ -1710,7 +1711,7 @@ inline void chessposition::CheckForImmediateStop()
 #ifdef STATISTICS
 void search_statistics()
 {
-    U64 n, i1, i2, i3;
+    U64 n, i1, i2, i3, i4;
     double f0, f1, f2, f3, f4, f5, f6, f7, f10, f11;
 
     printf("(ST)====Statistics====================================================================================================================================\n");
@@ -1718,6 +1719,7 @@ void search_statistics()
     // quiescense search statistics
     i1 = statistics.qs_n[0];
     i2 = statistics.qs_n[1];
+    i4 = statistics.qs_mindepth;
     n = i1 + i2;
     f0 = 100.0 * i2 / (double)n;
     f1 = 100.0 * statistics.qs_tt / (double)n;
@@ -1727,7 +1729,7 @@ void search_statistics()
     f4 =  i3 / (double)statistics.qs_loop_n;
     f5 = 100.0 * statistics.qs_move_delta / (double)i3;
     f6 = 100.0 * statistics.qs_moves_fh / (double)statistics.qs_moves;
-    printf("(ST) QSearch: %12lld   %%InCheck:  %5.2f   %%TT-Hits:  %5.2f   %%Std.Pat: %5.2f   %%DeltaPr: %5.2f   Mvs/Lp: %5.2f   %%DlPrM: %5.2f   %%FailHi: %5.2f\n", n, f0, f1, f2, f3, f4, f5, f6);
+    printf("(ST) QSearch: %12lld   %%InCheck:  %5.2f   %%TT-Hits:  %5.2f   %%Std.Pat: %5.2f   %%DeltaPr: %5.2f   Mvs/Lp: %5.2f   %%DlPrM: %5.2f   %%FailHi: %5.2f   mindepth: %3d\n", n, f0, f1, f2, f3, f4, f5, f6, i4);
 
     // general aplhabeta statistics
     n = statistics.ab_n;


### PR DESCRIPTION
STC:
ELO   | 9.15 +- 5.55 (95%)
SPRT  | 15.0+0.15s Threads=1 Hash=8MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 6080 W: 1311 L: 1151 D: 3618

LTC:
ELO   | 7.39 +- 4.53 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 7008 W: 1166 L: 1017 D: 4825
