### PR TITLE
Movesel

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1199,7 +1199,7 @@ public:
 public:
     void SetPreferredMoves(chessposition *p);  // for quiescence move selector
     void SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t kllm1, uint32_t kllm2, uint32_t counter, int excludemove);
-    chessmove* next();
+    uint32_t next();
 };
 
 extern U64 pawn_attacks_to[64][2];
@@ -1387,8 +1387,8 @@ public:
     void tbFilterRootMoves();
     void prepareStack();
     string movesOnStack();
-    bool playMove(chessmove *cm);
-    void unplayMove(chessmove *cm);
+    bool playMove(uint32_t mc);
+    void unplayMove(uint32_t mc);
     void playNullMove();
     void unplayNullMove();
     template <int Me> void updatePins();

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1174,6 +1174,7 @@ public:
 	string toStringWithValue();
 	void print();
     chessmove* getNextMove(int minval);
+    uint32_t chessmovelist::getAndRemoveNextMove();
 };
 
 #define CMPLIES 2

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1190,10 +1190,10 @@ public:
     int state;
     chessmovelist* captures;
     chessmovelist* quiets;
-    chessmove hashmove;
-    chessmove killermove1;
-    chessmove killermove2;
-    chessmove countermove;
+    uint32_t hashmove;
+    uint32_t killermove1;
+    uint32_t killermove2;
+    uint32_t countermove;
     int legalmovenum;
     bool onlyGoodCaptures;
     int16_t *cmptr[CMPLIES];

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1174,7 +1174,7 @@ public:
 	string toStringWithValue();
 	void print();
     chessmove* getNextMove(int minval);
-    uint32_t chessmovelist::getAndRemoveNextMove();
+    uint32_t getAndRemoveNextMove();
 };
 
 #define CMPLIES 2

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1134,6 +1134,7 @@ struct chessmovestack
 
 #define MAXMOVELISTLENGTH 256   // for lists of possible pseudo-legal moves
 
+string moveToString(uint32_t mc);
 
 class chessmove
 {
@@ -1297,10 +1298,10 @@ public:
     int nullmoveside;
     int nullmoveply = 0;
     chessmovelist rootmovelist;
-    chessmove bestmove;
-    int bestmovescore[MAXMULTIPV];
+    uint32_t bestmove;
     int lastbestmovescore;
-    chessmove pondermove;
+    int bestmovescore[MAXMULTIPV];
+    uint32_t pondermove;
     int LegalMoves[MAXDEPTH];
     uint32_t killer[MAXDEPTH][2];
     uint32_t bestFailingLow;
@@ -1314,7 +1315,7 @@ public:
     int useTb;
     int useRootmoveScore;
     int tbPosition;
-    chessmove defaultmove; // fallback if search in time trouble didn't finish a single iteration
+    uint32_t defaultmove; // fallback if search in time trouble didn't finish a single iteration
     chessmovelist captureslist[MAXDEPTH];
     chessmovelist quietslist[MAXDEPTH];
     chessmovelist singularcaptureslist[MAXDEPTH];   // extra move lists for singular testing

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -2350,8 +2350,8 @@ int chessposition::getBestPossibleCapture()
 void MoveSelector::SetPreferredMoves(chessposition *p)
 {
     pos = p;
-    hashmove.code = 0;
-    killermove1.code = killermove2.code = 0;
+    hashmove = 0;
+    killermove1 = killermove2 = 0;
     if (!p->isCheckbb)
     {
         onlyGoodCaptures = true;
@@ -2370,13 +2370,13 @@ void MoveSelector::SetPreferredMoves(chessposition *p)
 void MoveSelector::SetPreferredMoves(chessposition *p, uint16_t hshm, uint32_t kllm1, uint32_t kllm2, uint32_t counter, int excludemove)
 {
     pos = p;
-    hashmove.code = p->shortMove2FullMove(hshm);
-    if (kllm1 != hashmove.code)
-        killermove1.code = kllm1;
-    if (kllm2 != hashmove.code)
-        killermove2.code = kllm2;
-    if (counter != hashmove.code && counter != kllm1 && counter != kllm2)
-        countermove.code = counter;
+    hashmove = p->shortMove2FullMove(hshm);
+    if (kllm1 != hashmove)
+        killermove1 = kllm1;
+    if (kllm2 != hashmove)
+        killermove2 = kllm2;
+    if (counter != hashmove && counter != kllm1 && counter != kllm2)
+        countermove = counter;
     pos->getCmptr(&cmptr[0]);
     if (!excludemove)
     {
@@ -2403,9 +2403,9 @@ uint32_t MoveSelector::next()
         // fall through
     case HASHMOVESTATE:
         state++;
-        if (hashmove.code)
+        if (hashmove)
         {
-            return hashmove.code;
+            return hashmove;
         }
         // fall through
     case TACTICALINITSTATE:
@@ -2422,7 +2422,7 @@ uint32_t MoveSelector::next()
             }
             else {
                 m->value = INT_MIN;
-                if (m->code != hashmove.code)
+                if (m->code != hashmove)
                     return m->code;
             }
         }
@@ -2432,23 +2432,23 @@ uint32_t MoveSelector::next()
         // fall through
     case KILLERMOVE1STATE:
         state++;
-        if (pos->moveIsPseudoLegal(killermove1.code))
+        if (pos->moveIsPseudoLegal(killermove1))
         {
-            return killermove1.code;
+            return killermove1;
         }
         // fall through
     case KILLERMOVE2STATE:
         state++;
-        if (pos->moveIsPseudoLegal(killermove2.code))
+        if (pos->moveIsPseudoLegal(killermove2))
         {
-            return killermove2.code;
+            return killermove2;
         }
         // fall through
     case COUNTERMOVESTATE:
         state++;
-        if (pos->moveIsPseudoLegal(countermove.code))
+        if (pos->moveIsPseudoLegal(countermove))
         {
-            return countermove.code;
+            return countermove;
         }
         // fall through
     case QUIETINITSTATE:
@@ -2460,10 +2460,10 @@ uint32_t MoveSelector::next()
         uint32_t mc;
         while ((mc = quiets->getAndRemoveNextMove()))
         {
-            if (mc != hashmove.code
-                && mc != killermove1.code
-                && mc != killermove2.code
-                && mc != countermove.code)
+            if (mc != hashmove
+                && mc != killermove1
+                && mc != killermove2
+                && mc != countermove)
                 return mc;
         }
         state++;

--- a/src/learn.cpp
+++ b/src/learn.cpp
@@ -339,7 +339,7 @@ static void gensfenthread(searchthread* thr)
     raninit(&rnd, rndseed);
     chessmovelist movelist;
     U64 psvnums = 0;
-    chessmove nextmove;
+    uint32_t nmc;
     chessposition* pos = &thr->pos;
     pos->he_yes = 0ULL;
     pos->he_all = 0ULL;
@@ -441,8 +441,8 @@ static void gensfenthread(searchthread* thr)
             
 SKIP_SAVE:
             // preset move for next ply with the pv move
-            nextmove.code = pos->pvtable[pos->ply][0];
-            if (!nextmove.code)
+            nmc = pos->pvtable[pos->ply][0];
+            if (!nmc)
             {
                 // No move in pv => mate or stalemate
                 if (pos->isCheckbb) // Mate
@@ -453,7 +453,7 @@ SKIP_SAVE:
             }
 
             pos->prepareStack();
-            bool chooserandom = !nextmove.code || (random_move_count && ply >= random_move_minply && ply <= random_move_maxply && random_move_flag[ply]);
+            bool chooserandom = !nmc || (random_move_count && ply >= random_move_minply && ply <= random_move_maxply && random_move_flag[ply]);
 
             while (true)
             {
@@ -463,7 +463,7 @@ SKIP_SAVE:
                     if (random_multi_pv == 0)
                     {
                         i = ranval(&rnd) % movelist.length;
-                        nextmove.code = movelist.move[i].code;
+                        nmc = movelist.move[i].code;
                     }
                     else
                     {
@@ -475,11 +475,11 @@ SKIP_SAVE:
                         while (random_multi_pv_diff && pos->bestmovescore[0] > pos->bestmovescore[s - 1] + random_multi_pv_diff)
                             s--;
 
-                        nextmove.code = pos->multipvtable[ranval(&rnd) % s][0];
+                        nmc = pos->multipvtable[ranval(&rnd) % s][0];
                     }
                 }
 
-                bool legal = pos->playMove(&nextmove);
+                bool legal = pos->playMove(nmc);
 
                 if (legal)
                 {
@@ -743,7 +743,7 @@ void convert(vector<string> args)
                 if (n % 10000 == 0)
                 {
                     cerr << "======================================================================\n";
-                    for (int i = 0; i < 7; i++)
+                    for (i = 0; i < 7; i++)
                     {
                         double avh = evalsum[0][i] / (double)evaln[i];
                         double avn = evalsum[1][i] / (double)evaln[i];

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -154,10 +154,10 @@ long long engine::perft(int depth, bool dotests, bool printsysteminfo)
 
     for (int i = 0; i < movelist.length; i++)
     {
-        if (rootpos->playMove(&movelist.move[i]))
+        if (rootpos->playMove(movelist.move[i].code))
         {
             retval += perft(depth - 1, dotests);
-            rootpos->unplayMove(&movelist.move[i]);
+            rootpos->unplayMove(movelist.move[i].code);
         }
     }
     return retval;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -601,7 +601,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
         for (int i = 0; i < movelist->length; i++)
         {
-            uint32_t mc = movelist->move[i].code;
+            mc = movelist->move[i].code;
 
             if (!see(mc, rbeta - staticeval))
                 continue;
@@ -973,9 +973,9 @@ int chessposition::rootsearch(int alpha, int beta, int depth, int inWindowLast)
         uint32_t fullhashmove = shortMove2FullMove(hashmovecode);
         if (fullhashmove)
         {
-            if (bestmove.code != fullhashmove) {
-                bestmove.code = fullhashmove;
-                pondermove.code = 0;
+            if (bestmove != fullhashmove) {
+                bestmove = fullhashmove;
+                pondermove = 0;
             }
             updatePvTable(fullhashmove, false);
             if (score > alpha) bestmovescore[0] = score;
@@ -1144,14 +1144,14 @@ int chessposition::rootsearch(int alpha, int beta, int depth, int inWindowLast)
             {
                 SDEBUGDO(isDebugPv, pvaborttype[0] = isDebugMove ? PVA_BESTMOVE : debugMovePlayed ? PVA_NOTBESTMOVE : PVA_OMITTED;);
                 updatePvTable(m->code, true);
-                if (bestmove.code != pvtable[0][0])
+                if (bestmove != pvtable[0][0])
                 {
-                    bestmove.code = pvtable[0][0];
-                    pondermove.code = pvtable[0][1];
+                    bestmove = pvtable[0][0];
+                    pondermove = pvtable[0][1];
                 }
                 else if (pvtable[0][1]) {
                     // use new ponder move
-                    pondermove.code = pvtable[0][1];
+                    pondermove = pvtable[0][1];
                 }
                 alpha = score;
                 bestmovescore[0] = score;
@@ -1188,8 +1188,8 @@ int chessposition::rootsearch(int alpha, int beta, int depth, int inWindowLast)
         else if (!isMultiPV)
         {
             // at fail low don't overwrite an existing move
-            if (!bestmove.code)
-                bestmove = *m;
+            if (!bestmove)
+                bestmove = m->code;
         }
     }
 
@@ -1201,7 +1201,7 @@ int chessposition::rootsearch(int alpha, int beta, int depth, int inWindowLast)
             return alpha;
     }
     else {
-        tp.addHash(hash, alpha, staticeval, eval_type, depth, (uint16_t)bestmove.code);
+        tp.addHash(hash, alpha, staticeval, eval_type, depth, (uint16_t)bestmove);
         SDEBUGDO(isDebugPv, tp.debugSetPv(hash, movesOnStack() + " depth=" + to_string(depth)););
         return alpha;
     }
@@ -1291,14 +1291,14 @@ static void search_gen1(searchthread *thr)
         if (pos->rootmovelist.length == 0)
         {
             // mate / stalemate
-            pos->bestmove.code = 0;
+            pos->bestmove = 0;
             score = pos->bestmovescore[0] =  (pos->isCheckbb ? SCOREBLACKWINS : SCOREDRAW);
         }
         else if (isDraw)
         {
             // remis via repetition or 50 moves rule
-            pos->bestmove.code = 0;
-            pos->pondermove.code = 0;
+            pos->bestmove = 0;
+            pos->pondermove = 0;
             score = pos->bestmovescore[0] = SCOREDRAW;
         }
         else
@@ -1389,18 +1389,18 @@ static void search_gen1(searchthread *thr)
             else {
                 // The only two cases that bestmove is not set can happen if alphabeta hit the TP table or we are in TB
                 // so get bestmovecode from there or it was a TB hit so just get the first rootmove
-                if (!pos->bestmove.code)
+                if (!pos->bestmove)
                 {
                     uint16_t mc = 0;
                     int dummystaticeval;
                     tp.probeHash(pos->hash, &score, &dummystaticeval, &mc, MAXDEPTH, alpha, beta, 0);
-                    pos->bestmove.code = pos->shortMove2FullMove(mc);
-                    pos->pondermove.code = 0;
+                    pos->bestmove = pos->shortMove2FullMove(mc);
+                    pos->pondermove = 0;
                 }
                     
                 // still no bestmove...
-                if (!pos->bestmove.code && pos->rootmovelist.length > 0 && !isDraw)
-                    pos->bestmove.code = pos->rootmovelist.move[0].code;
+                if (!pos->bestmove && pos->rootmovelist.length > 0 && !isDraw)
+                    pos->bestmove = pos->rootmovelist.move[0].code;
 
                 if (pos->rootmovelist.length == 1 && !pos->tbPosition && en.endtime1 && en.pondersearch != PONDERING && pos->lastbestmovescore != NOSCORE)
                     // Don't report score of instamove; use the score of last position instead
@@ -1445,10 +1445,10 @@ static void search_gen1(searchthread *thr)
             constantRootMoves++;
         }
 
-        if (lastBestMove != pos->bestmove.code)
+        if (lastBestMove != pos->bestmove)
         {
             // New best move is found; reset thinking time
-            lastBestMove = pos->bestmove.code;
+            lastBestMove = pos->bestmove;
             constantRootMoves = 0;
         }
 
@@ -1502,7 +1502,7 @@ static void search_gen1(searchthread *thr)
                 bestthr = hthr;
             }
         }
-        if (pos->bestmove.code != bestthr->pos.bestmove.code)
+        if (pos->bestmove != bestthr->pos.bestmove)
         {
             // copy best moves and score from best thread to thread 0
             int i = 0;
@@ -1528,29 +1528,29 @@ static void search_gen1(searchthread *thr)
         string strBestmove;
         string strPonder = "";
 
-        if (!pos->bestmove.code && !isDraw)
+        if (!pos->bestmove && !isDraw)
         {
             // Not enough time to get any bestmove? Fall back to default move
             pos->bestmove = pos->defaultmove;
-            pos->pondermove.code = 0;
+            pos->pondermove = 0;
         }
 
-        strBestmove = pos->bestmove.toString();
+        strBestmove = moveToString(pos->bestmove);
 
-        if (!pos->pondermove.code)
+        if (!pos->pondermove)
         {
             // Get the ponder move from TT
-            pos->playMove(pos->bestmove.code);
+            pos->playMove(pos->bestmove);
             uint16_t pondershort = tp.getMoveCode(pos->hash);
-            pos->pondermove.code = pos->shortMove2FullMove(pondershort);
-            pos->unplayMove(pos->bestmove.code);
+            pos->pondermove = pos->shortMove2FullMove(pondershort);
+            pos->unplayMove(pos->bestmove);
         }
 
         // Save pondermove in rootposition for time management of following search
         en.rootposition.pondermove = pos->pondermove;
 
-        if (pos->pondermove.code)
-            strPonder = " ponder " + pos->pondermove.toString();
+        if (pos->pondermove)
+            strPonder = " ponder " + moveToString(pos->pondermove);
 
         cout << "bestmove " + strBestmove + strPonder + "\n";
 
@@ -1724,7 +1724,7 @@ void search_statistics()
     f4 =  i3 / (double)statistics.qs_loop_n;
     f5 = 100.0 * statistics.qs_move_delta / (double)i3;
     f6 = 100.0 * statistics.qs_moves_fh / (double)statistics.qs_moves;
-    printf("(ST) QSearch: %12lld   %%InCheck:  %5.2f   %%TT-Hits:  %5.2f   %%Std.Pat: %5.2f   %%DeltaPr: %5.2f   Mvs/Lp: %5.2f   %%DlPrM: %5.2f   %%FailHi: %5.2f   mindepth: %3d\n", n, f0, f1, f2, f3, f4, f5, f6, i4);
+    printf("(ST) QSearch: %12lld   %%InCheck:  %5.2f   %%TT-Hits:  %5.2f   %%Std.Pat: %5.2f   %%DeltaPr: %5.2f   Mvs/Lp: %5.2f   %%DlPrM: %5.2f   %%FailHi: %5.2f   mindepth: %3lld\n", n, f0, f1, f2, f3, f4, f5, f6, i4);
 
     // general aplhabeta statistics
     n = statistics.ab_n;

--- a/src/texel.cpp
+++ b/src/texel.cpp
@@ -598,7 +598,6 @@ static double TexelEvalErrorDiff(tuner* tn, precalculated* precalc)
     positiontuneset* p = (positiontuneset*)texelpts;
     for (U64 i = 0; i < texelptsnum; i++)
     {
-        evalparam* e = (evalparam*)((char*)p + sizeof(positiontuneset));
         precalculated* prec = precalc + i;
         int index = prec->index;
 
@@ -1057,7 +1056,7 @@ static double getAvgParamVal(int iParam)
     {
         evalparam* e = (evalparam*)((char*)p + sizeof(positiontuneset));
         if (p->sc != SCALE_DRAW)
-            pSum += TAPEREDANDSCALEDEVAL(getValueByCoeff(*pos.tps.ev, p, e, false, iParam), p->ph, p->sc);
+            pSum += TAPEREDANDSCALEDEVAL(getValueByCoeff(*pos.tps.ev, p, e, nullptr, false, iParam), p->ph, p->sc);
         p = (positiontuneset*)((char*)p + sizeof(positiontuneset) + p->num * sizeof(evalparam));
     }
     double pAvg = pSum / (double)texelptsnum;
@@ -1078,8 +1077,8 @@ static double getCorrelationCoeff(int ix, int iy, double ax, double ay)
         evalparam* e = (evalparam*)((char*)p + sizeof(positiontuneset));
         if (p->sc != SCALE_DRAW)
         {
-            px = TAPEREDANDSCALEDEVAL(getValueByCoeff(*pos.tps.ev, p, e, false, ix), p->ph, p->sc);
-            py = TAPEREDANDSCALEDEVAL(getValueByCoeff(*pos.tps.ev, p, e, false, iy), p->ph, p->sc);
+            px = TAPEREDANDSCALEDEVAL(getValueByCoeff(*pos.tps.ev, p, e, nullptr, false, ix), p->ph, p->sc);
+            py = TAPEREDANDSCALEDEVAL(getValueByCoeff(*pos.tps.ev, p, e, nullptr, false, iy), p->ph, p->sc);
         }
         counter += (px - ax) * (py - ay);
         denominatorfactorx += (px - ax) * (px - ax);

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -338,9 +338,9 @@ string AlgebraicFromShort(string s, chessposition *pos)
             && ((to & 0x40) || ((to & 0x07) == (GETTO(ml.move[i].code) & 0x07))))
         {
             // test if the move is legal; otherwise we need to search further
-            if (pos->playMove(&ml.move[i]))
+            if (pos->playMove(ml.move[i].code))
             {
-                pos->unplayMove(&ml.move[i]);
+                pos->unplayMove(ml.move[i].code);
                 retval = ml.move[i].toString();
                 break;
             }


### PR DESCRIPTION
This switches from chessmove struct to simple uint32_t code where value of move is not used.
This new API is used to accelerate the move selector by shorten the remaining movelist with each next().
Also corrects some warnings and errors in Texel code.

The following tests where done before some additional cleanups. Lets hope I didn't break anything.

STC:
ELO   | 17.47 +- 7.99 (95%)
SPRT  | 15.0+0.15s Threads=1 Hash=8MB
LLR   | 3.00 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2826 W: 621 L: 479 D: 1726

LTC:
ELO   | 8.46 +- 4.94 (95%)
SPRT  | 60.0+0.6s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
Games | N: 5959 W: 1010 L: 865 D: 4084
