### PR TITLE
Searchp1

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -50,7 +50,7 @@ struct searchparamset {
 #ifdef EVALTUNE
     searchparam SP(deltapruningmargin, 4000);
 #else
-    searchparam SP(deltapruningmargin, 100);
+    searchparam SP(deltapruningmargin, 160);
 #endif
     // LMR table
     searchparam SP(lmrlogf0, 150);


### PR DESCRIPTION
STC:
ELO   | 5.86 +- 3.55 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 3.07 (-2.94, 2.94) [0.00, 4.00]
Games | N: 11376 W: 1860 L: 1668 D: 7848

LTC:
ELO   | 1.73 +- 1.38 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 4.00]
Games | N: 50234 W: 5310 L: 5060 D: 39864