### PR TITLE
Scale

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -22,7 +22,7 @@
 
 // Disable this to compile without NNUE evaluation
 #define NNUE
-#define NNUEDEFAULT nn-72b4488f79-20210510.nnue
+#define NNUEDEFAULT nn-fb50f1a2b1-20210705.nnue
 
 // Enable to get statistical values about various search features
 //#define STATISTICS

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -361,7 +361,7 @@ template <NnueType Nt> int chessposition::NnueGetEval()
     NnueCl1->Propagate(network.hidden2_values, network.hidden2_clipped);
     NnueOut->OutLayer(network.hidden2_clipped, &network.out_value);
 
-    return network.out_value * NnueValueScale / 1024;
+    return network.out_value * 64 / 1024;
 }
 
 
@@ -481,6 +481,19 @@ bool NnueNetworkLayer::ReadWeights(NnueNetsource_t is)
         }
 
     free(weightbuffer);
+
+    if (outputdims == 1)
+    {
+        //cout << (int)bias[0] << " ... ";
+        bias[0] = bias[0] * NnueValueScale / 64;
+        //cout << (int)bias[0] << "\n";
+        for (unsigned int c = 0; c < inputdims; c++)
+        {
+            //cout << (int)weight[c] << " ... ";
+            weight[c] = weight[c] * NnueValueScale / 64;
+            //cout << (int)weight[c] << "\n";
+        }
+    }
 
     return !NNUEREADFAIL(is);
 }

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -349,7 +349,7 @@ template <NnueType Nt> void chessposition::Transform(clipped_t *output)
 }
 
 
-eval NnueValueScale = 41;
+eval NnueValueScale = 64;
 
 
 template <NnueType Nt> int chessposition::NnueGetEval()
@@ -361,7 +361,7 @@ template <NnueType Nt> int chessposition::NnueGetEval()
     NnueCl1->Propagate(network.hidden2_values, network.hidden2_clipped);
     NnueOut->OutLayer(network.hidden2_clipped, &network.out_value);
 
-    return network.out_value * 64 / 1024;
+    return network.out_value * NnueValueScale / 1024;
 }
 
 
@@ -481,19 +481,6 @@ bool NnueNetworkLayer::ReadWeights(NnueNetsource_t is)
         }
 
     free(weightbuffer);
-
-    if (outputdims == 1)
-    {
-        //cout << (int)bias[0] << " ... ";
-        bias[0] = bias[0] * NnueValueScale / 64;
-        //cout << (int)bias[0] << "\n";
-        for (unsigned int c = 0; c < inputdims; c++)
-        {
-            //cout << (int)weight[c] << " ... ";
-            weight[c] = weight[c] * NnueValueScale / 64;
-            //cout << (int)weight[c] << "\n";
-        }
-    }
 
     return !NNUEREADFAIL(is);
 }


### PR DESCRIPTION
STC1:
ELO   | 4.08 +- 4.07 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 8768 W: 1426 L: 1323 D: 6019

STC2:
ELO   | 6.74 +- 5.03 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 5672 W: 935 L: 825 D: 3912

LTC:
ELO   | 4.52 +- 3.47 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 7840 W: 851 L: 749 D: 6240
