### PR TITLE
Save to tt more often.

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -801,6 +801,7 @@ void learn(vector<string> args);
 #define BOUNDMASK   0x03
 #define HASHALPHA   0x01
 #define HASHBETA    0x02
+#define HASHUNKNOWN 0x03
 #define HASHEXACT   0x00
 
 class zobrist

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -521,6 +521,8 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             staticeval = -staticevalstack[mstop - 1] + CEVAL(eps.eTempo, 2);
         else
             staticeval = getEval<NOTRACE>();
+
+        tp.addHash(hash, staticeval, staticeval, HASHUNKNOWN, 0, hashmovecode);
     }
     staticevalstack[mstop] = staticeval;
 
@@ -618,6 +620,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                     // ProbCut off
                     STATISTICSINC(prune_probcut);
                     SDEBUGDO(isDebugPv, pvabortval[ply] = probcutscore; pvaborttype[ply] = PVA_PROBCUTPRUNED; pvadditionalinfo[ply] = "pruned by " + movelist->move[i].toString(););
+                    tp.addHash(hash, probcutscore, staticeval, HASHBETA, depth - 3, mc);
                     return probcutscore;
                 }
             }


### PR DESCRIPTION
STC:
ELO   | 10.54 +- 5.63 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4616 W: 800 L: 660 D: 3156

LTC:
ELO   | 7.36 +- 4.03 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 6328 W: 771 L: 637 D: 4920
