### PR TITLE
Legal moves cleanup

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1333,7 +1333,7 @@ public:
     int lastbestmovescore;
     int bestmovescore[MAXMULTIPV];
     uint32_t pondermove;
-    int LegalMoves[MAXDEPTH];
+    int CurrentMoveNum[MAXDEPTH];
     uint32_t killer[MAXDEPTH][2];
     uint32_t bestFailingLow;
     int threadindex;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -784,7 +784,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 reduction -= PVNode;
 
                 // adjust reduction with opponents move number
-                reduction -= (LegalMoves[ply] >= sps.lmropponentmovecount);
+                reduction -= (CurrentMoveNum[ply] >= sps.lmropponentmovecount);
 
                 STATISTICSINC(red_pi[positionImproved]);
                 STATISTICSADD(red_lmr[positionImproved], reductiontable[positionImproved][depth][min(63, legalMoves + 1)]);
@@ -814,11 +814,10 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         if (!playMove(mc))
             continue;
 
-        legalMoves++;
         SDEBUGDO(isDebugMove, debugMovePlayed = true;);
         STATISTICSINC(moves_played[(bool)ISTACTICAL(mc)]);
 
-        LegalMoves[ply] = legalMoves;
+        CurrentMoveNum[ply] = ++legalMoves;
         SDEBUGDO(isDebugMove, pvadditionalinfo[ply-1] = ""; );
 
         if (reduction)


### PR DESCRIPTION
STC:
ELO   | 2.20 +- 3.02 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 0.00]
GAMES | N: 16288 W: 2664 L: 2561 D: 11063

LTC:
ELO   | 0.59 +- 1.63 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [-4.00, 0.00]
GAMES | N: 37088 W: 3971 L: 3908 D: 29209
