### PR TITLE
Hashmove - reduce reduction at PV nodes for all but the bad hash moves

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -779,9 +779,10 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 // adjust reduction by stats value
                 reduction -= stats / (sps.lmrstatsratio * 8);
 
-                // adjust reduction at PV nodes
+                // less reduction at PV nodes
                 reduction -= PVNode;
 
+                // even lesser reduction at PV nodes for all but bad hash moves
                 reduction -= (PVNode && (!tpHit || hashmovecode != (uint16_t)mc || hashscore > alpha));
 
                 // adjust reduction with opponents move number
@@ -791,6 +792,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 STATISTICSADD(red_lmr[positionImproved], reductiontable[positionImproved][depth][min(63, legalMoves + 1)]);
                 STATISTICSADD(red_history, -stats / (sps.lmrstatsratio * 8));
                 STATISTICSADD(red_pv, -(int)PVNode);
+                STATISTICSADD(red_pv, -(int)(PVNode && (!tpHit || hashmovecode != (uint16_t)mc || hashscore > alpha)));
                 STATISTICSDO(int red0 = reduction);
 
                 reduction = min(depth, max(0, reduction));

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -780,6 +780,8 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 reduction -= stats / (sps.lmrstatsratio * 8);
 
                 // adjust reduction at PV nodes
+                reduction -= PVNode;
+
                 reduction -= (PVNode && (!tpHit || hashmovecode != (uint16_t)mc || hashscore > alpha));
 
                 // adjust reduction with opponents move number

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -780,7 +780,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 reduction -= stats / (sps.lmrstatsratio * 8);
 
                 // adjust reduction at PV nodes
-                reduction -= PVNode;
+                reduction -= (PVNode && (!tpHit || hashmovecode != (uint16_t)mc || hashscore > alpha));
 
                 // adjust reduction with opponents move number
                 reduction -= (CurrentMoveNum[ply] >= sps.lmropponentmovecount);


### PR DESCRIPTION
STC:
ELO   | 2.73 +- 2.18 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.99 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 30408 W: 4891 L: 4652 D: 20865

LTC:
ELO   | 5.59 +- 3.34 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.94 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 8448 W: 927 L: 791 D: 6730
