### PR TITLE
Hashmove2 - History bonus for quiet hash moves failing high

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -469,8 +469,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     {
         if (hashscore >= beta && hashmovecode && !mailbox[GETTO(hashmovecode)])
         {
-            int from = GETFROM(hashmovecode);
-            int piece = mailbox[from];
+            int piece = mailbox[GETFROM(hashmovecode)];
             mc = (piece << 28) | hashmovecode;
             updateHistory(mc, depth * depth);
         }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -467,8 +467,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     bool tpHit = tp.probeHash(newhash, &hashscore, &staticeval, &hashmovecode, depth, alpha, beta, ply);
     if (tpHit && !rep && !PVNode)
     {
-        int to;
-        if (hashscore >= beta && hashmovecode && (to = GETTO(hashmovecode)) && !mailbox[to])
+        if (hashscore >= beta && hashmovecode && !mailbox[GETTO(hashmovecode)])
         {
             int from = GETFROM(hashmovecode);
             int piece = mailbox[from];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -468,7 +468,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     if (tpHit && !rep && !PVNode)
     {
         int to;
-        if (0 && hashscore >= beta && hashmovecode && (to = GETTO(hashmovecode)) && !mailbox[to])
+        if (hashscore >= beta && hashmovecode && (to = GETTO(hashmovecode)) && !mailbox[to])
         {
             int from = GETFROM(hashmovecode);
             int piece = mailbox[from];

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -461,12 +461,14 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     SDEBUGDO(isDebugPv, pvaborttype[ply + 1] = PVA_UNKNOWN; pvdepth[ply] = depth; pvalpha[ply] = alpha; pvbeta[ply] = beta; pvmovenum[ply] = 0;);
 #endif
 
+    getCmptr();
+
     // TT lookup
     bool tpHit = tp.probeHash(newhash, &hashscore, &staticeval, &hashmovecode, depth, alpha, beta, ply);
     if (tpHit && !rep && !PVNode)
     {
         int to;
-        if (hashscore >= beta && hashmovecode && (to = GETTO(hashmovecode)) && !mailbox[to])
+        if (0 && hashscore >= beta && hashmovecode && (to = GETTO(hashmovecode)) && !mailbox[to])
         {
             int from = GETFROM(hashmovecode);
             int piece = mailbox[from];
@@ -604,7 +606,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     }
 
     MoveSelector* ms = (excludeMove ? &extensionMoveSelector[ply] : &moveSelector[ply]);
-    getCmptr();
 
     // ProbCut
     if (!PVNode && depth >= sps.probcutmindepth && abs(beta) < SCOREWHITEWINS)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -465,6 +465,14 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     bool tpHit = tp.probeHash(newhash, &hashscore, &staticeval, &hashmovecode, depth, alpha, beta, ply);
     if (tpHit && !rep && !PVNode)
     {
+        int to;
+        if (hashscore >= beta && hashmovecode && (to = GETTO(hashmovecode)) && !mailbox[to])
+        {
+            int from = GETFROM(hashmovecode);
+            int piece = mailbox[from];
+            mc = (piece << 28) | hashmovecode;
+            updateHistory(mc, depth * depth);
+        }
         // not a single repetition; we can (almost) safely trust the hash value
         STATISTICSINC(ab_tt);
 #ifdef SDEBUG


### PR DESCRIPTION
STC:
ELO   | 1.99 +- 1.53 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 59464 W: 9176 L: 8835 D: 41453

LTC:
ELO   | 2.96 +- 2.21 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 19376 W: 2058 L: 1893 D: 15425