### PR TITLE
Tm - more aggressive time usage for x+y time control

### DIFF
--- a/src/board.cpp
+++ b/src/board.cpp
@@ -464,7 +464,7 @@ int chessposition::getFromFen(const char* sFen)
     if (numToken > 5)
     {
         try {
-            fullmovescounter = max(1, stoi(token[5]));
+            fullmovescounter = stoi(token[5]);
         }
         catch (...) {}
     }

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -464,7 +464,7 @@ int chessposition::getFromFen(const char* sFen)
     if (numToken > 5)
     {
         try {
-            fullmovescounter = stoi(token[5]);
+            fullmovescounter = max(1, stoi(token[5]));
         }
         catch (...) {}
     }

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1598,18 +1598,18 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         en.endtime2 = startTime + min(max(0, timetouse - overhead * en.movestogo), f2 * timetouse / (en.movestogo + 1) / 10) * en.frequency / 1000;
     }
     else if (timetouse) {
-        int ph = en.sthread[0].pos.phase();
-        int ph2 = max(0, 40 - en.sthread[0].pos.fullmovescounter) / 8;
+        int ph = en.sthread[0].pos.phase();                             // 0...255
+        int ph2 = max(255, en.sthread[0].pos.fullmovescounter * 6);     // 0...255
         if (timeinc)
         {
             // sudden death with increment; split the remaining time in (256-phase) timeslots
             // f1: stop soon after 5..17 timeslot
             // f2: stop immediately after 15..27 timeslots
-            int f1 = max(5, 17 - constance) + ph2 / 2;
-            int f2 = max(15, 27 - constance) + ph2;
+            int f1 = max(5, 17 - constance);
+            int f2 = max(15, 27 - constance);
             if (complete)
-                en.endtime1 = startTime + max(timeinc, f1 * (timetouse + timeinc) / (256 - ph)) * en.frequency / 1000;
-            en.endtime2 = startTime + min(max(0, timetouse - overhead), max(timeinc, f2 * (timetouse + timeinc) / (256 - ph))) * en.frequency / 1000;
+                en.endtime1 = startTime + max(timeinc, f1 * (timetouse + timeinc) / ((128 - ph / 2) + (128 - ph2 / 2))) * en.frequency / 1000;
+            en.endtime2 = startTime + min(max(0, timetouse - overhead), max(timeinc, f2 * (timetouse + timeinc) / ((128 - ph / 2) + (128 - ph2 / 2)))) * en.frequency / 1000;
         }
         else {
             // sudden death without increment; play for another x;y moves
@@ -1633,6 +1633,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
 
 #ifdef TDEBUG
     printf("info string Time for this move: %4.3f  /  %4.3f\n", (en.endtime1 - en.starttime) / (double)en.frequency, (en.endtime2 - en.starttime) / (double)en.frequency);
+    if (timeinc) printf("info string Timefactor (use/inc): %d\n", timetouse / timeinc);
 #endif
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1598,13 +1598,13 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         en.endtime2 = startTime + min(max(0, timetouse - overhead * en.movestogo), f2 * timetouse / (en.movestogo + 1) / 10) * en.frequency / 1000;
     }
     else if (timetouse) {
-        int ph = en.sthread[0].pos.phase();                             // 0...255
-        int ph2 = min(255, en.sthread[0].pos.fullmovescounter * 6);     // 0...255
         if (timeinc)
         {
-            // sudden death with increment; split the remaining time in (256-phase) timeslots
+            // sudden death with increment; split the remaining time in n timeslots depending on material phase and move number
             // f1: stop soon after 5..17 timeslot
             // f2: stop immediately after 15..27 timeslots
+            int ph = en.sthread[0].pos.phase();                             // 0...255
+            int ph2 = min(255, en.sthread[0].pos.fullmovescounter * 6);     // 0...255
             int f1 = max(5, 17 - constance);
             int f2 = max(15, 27 - constance);
             if (complete)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1601,7 +1601,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
     }
     else if (timetouse) {
         int ph = en.sthread[0].pos.phase();
-        int ph2 = max(0, 40 - en.sthread[0].pos.fullmovescounter) / 2;
+        int ph2 = max(0, 30 - en.sthread[0].pos.fullmovescounter) / 2;
         if (timeinc)
         {
             // sudden death with increment; split the remaining time in (256-phase) timeslots

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1608,8 +1608,8 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
             int f1 = max(5, 17 - constance);
             int f2 = max(15, 27 - constance);
             if (complete)
-                en.endtime1 = startTime + max(timeinc, f1 * (timetouse + timeinc) / ((128 - ph / 2) + (128 - ph2 / 2))) * en.frequency / 1000;
-            en.endtime2 = startTime + min(max(0, timetouse - overhead), max(timeinc, f2 * (timetouse + timeinc) / ((128 - ph / 2) + (128 - ph2 / 2)))) * en.frequency / 1000;
+                en.endtime1 = startTime + max(timeinc, f1 * (timetouse + timeinc) / (256 - (ph + ph2) / 2)) * en.frequency / 1000;
+            en.endtime2 = startTime + min(max(0, timetouse - overhead), max(timeinc, f2 * (timetouse + timeinc) / (256 - (ph + ph2) / 2))) * en.frequency / 1000;
         }
         else {
             // sudden death without increment; play for another x;y moves

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1599,7 +1599,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
     }
     else if (timetouse) {
         int ph = en.sthread[0].pos.phase();                             // 0...255
-        int ph2 = max(255, en.sthread[0].pos.fullmovescounter * 6);     // 0...255
+        int ph2 = min(255, en.sthread[0].pos.fullmovescounter * 6);     // 0...255
         if (timeinc)
         {
             // sudden death with increment; split the remaining time in (256-phase) timeslots

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1604,7 +1604,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
             // f1: stop soon after 5..17 timeslot
             // f2: stop immediately after 15..27 timeslots
             int ph = en.sthread[0].pos.phase();                             // 0...255
-            int ph2 = min(255, en.sthread[0].pos.fullmovescounter * 6);     // 0...255
+            int ph2 = 256 - min(255, en.sthread[0].pos.fullmovescounter * 6);     // 0...255
             int f1 = max(5, 17 - constance);
             int f2 = max(15, 27 - constance);
             if (complete)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1336,6 +1336,7 @@ static void search_gen1(searchthread *thr)
                 delta = min(SCOREWHITEWINS, delta + delta / sps.aspincratio + sps.aspincbase);
                 inWindow = 0;
                 reportedThisDepth = false;
+                constantRootMoves--;
             }
             else if (score == beta)
             {
@@ -1344,6 +1345,7 @@ static void search_gen1(searchthread *thr)
                 delta = min(SCOREWHITEWINS, delta + delta / sps.aspincratio + sps.aspincbase);
                 inWindow = 2;
                 reportedThisDepth = false;
+                constantRootMoves--;
             }
             else
             {
@@ -1447,7 +1449,7 @@ static void search_gen1(searchthread *thr)
             thr->depth++;
             if (en.pondersearch == PONDERING && thr->depth > maxdepth) thr->depth--;  // stay on maxdepth when pondering
             reportedThisDepth = true;
-            constantRootMoves++;
+            constantRootMoves = max(constantRootMoves + 1, 0);
         }
 
         if (lastBestMove != pos->bestmove)
@@ -1599,13 +1601,14 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
     }
     else if (timetouse) {
         int ph = en.sthread[0].pos.phase();
+        int ph2 = max(0, 40 - en.sthread[0].pos.fullmovescounter) / 2;
         if (timeinc)
         {
             // sudden death with increment; split the remaining time in (256-phase) timeslots
             // f1: stop soon after 5..17 timeslot
             // f2: stop immediately after 15..27 timeslots
-            int f1 = max(5, 17 - constance);
-            int f2 = max(15, 27 - constance);
+            int f1 = max(5, 17 - constance) + ph2 / 4;
+            int f2 = max(15, 27 - constance) + ph2;
             if (complete)
                 en.endtime1 = startTime + max(timeinc, f1 * (timetouse + timeinc) / (256 - ph)) * en.frequency / 1000;
             en.endtime2 = startTime + min(max(0, timetouse - overhead), max(timeinc, f2 * (timetouse + timeinc) / (256 - ph))) * en.frequency / 1000;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1336,7 +1336,6 @@ static void search_gen1(searchthread *thr)
                 delta = min(SCOREWHITEWINS, delta + delta / sps.aspincratio + sps.aspincbase);
                 inWindow = 0;
                 reportedThisDepth = false;
-                constantRootMoves--;
             }
             else if (score == beta)
             {
@@ -1345,7 +1344,6 @@ static void search_gen1(searchthread *thr)
                 delta = min(SCOREWHITEWINS, delta + delta / sps.aspincratio + sps.aspincbase);
                 inWindow = 2;
                 reportedThisDepth = false;
-                constantRootMoves--;
             }
             else
             {
@@ -1449,7 +1447,7 @@ static void search_gen1(searchthread *thr)
             thr->depth++;
             if (en.pondersearch == PONDERING && thr->depth > maxdepth) thr->depth--;  // stay on maxdepth when pondering
             reportedThisDepth = true;
-            constantRootMoves = max(constantRootMoves + 1, 0);
+            constantRootMoves++;
         }
 
         if (lastBestMove != pos->bestmove)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1601,15 +1601,15 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         if (timeinc)
         {
             // sudden death with increment; split the remaining time in n timeslots depending on material phase and move number
+            // ph: phase of the game averaging material and move number
             // f1: stop soon after 5..17 timeslot
             // f2: stop immediately after 15..27 timeslots
-            int ph = en.sthread[0].pos.phase();                             // 0...255
-            int ph2 = 256 - min(255, en.sthread[0].pos.fullmovescounter * 6);     // 0...255
+            int ph = (en.sthread[0].pos.phase() + min(255, en.sthread[0].pos.fullmovescounter * 6)) / 2;
             int f1 = max(5, 17 - constance);
             int f2 = max(15, 27 - constance);
             if (complete)
-                en.endtime1 = startTime + max(timeinc, f1 * (timetouse + timeinc) / (256 - (ph + ph2) / 2)) * en.frequency / 1000;
-            en.endtime2 = startTime + min(max(0, timetouse - overhead), max(timeinc, f2 * (timetouse + timeinc) / (256 - (ph + ph2) / 2))) * en.frequency / 1000;
+                en.endtime1 = startTime + max(timeinc, f1 * (timetouse + timeinc) / (256 - ph)) * en.frequency / 1000;
+            en.endtime2 = startTime + min(max(0, timetouse - overhead), max(timeinc, f2 * (timetouse + timeinc) / (256 - ph))) * en.frequency / 1000;
         }
         else {
             // sudden death without increment; play for another x;y moves

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1577,8 +1577,8 @@ static void search_gen1(searchthread *thr)
 
 void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
 {
-    int timetouse = (en.isWhite ? en.wtime : en.btime);
     int timeinc = (en.isWhite ? en.winc : en.binc);
+    int timetouse = max(timeinc, (en.isWhite ? en.wtime : en.btime));
     int overhead = en.moveOverhead + 8 * en.Threads;
     int constance = constantRootMoves * 2 + en.ponderhit * 4;
 
@@ -1599,13 +1599,13 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
     }
     else if (timetouse) {
         int ph = en.sthread[0].pos.phase();
-        int ph2 = max(0, 30 - en.sthread[0].pos.fullmovescounter) / 2;
+        int ph2 = max(0, 40 - en.sthread[0].pos.fullmovescounter) / 8;
         if (timeinc)
         {
             // sudden death with increment; split the remaining time in (256-phase) timeslots
             // f1: stop soon after 5..17 timeslot
             // f2: stop immediately after 15..27 timeslots
-            int f1 = max(5, 17 - constance) + ph2 / 4;
+            int f1 = max(5, 17 - constance) + ph2 / 2;
             int f2 = max(15, 27 - constance) + ph2;
             if (complete)
                 en.endtime1 = startTime + max(timeinc, f1 * (timetouse + timeinc) / (256 - ph)) * en.frequency / 1000;


### PR DESCRIPTION
STC:
ELO   | 5.66 +- 3.48 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 4.00]
GAMES | N: 11240 W: 1745 L: 1562 D: 7933

LTC:
ELO   | 7.15 +- 3.85 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.99 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 6024 W: 644 L: 520 D: 4860

SMP:
ELO   | 5.10 +- 3.54 (95%)
SPRT  | 5.0+0.05s Threads=8 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 9136 W: 1195 L: 1061 D: 6880
