### PR TITLE
Futility Pruning retuned

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,8 +72,8 @@ struct searchparamset {
     searchparam SP(futilitymindepth, 8);
     searchparam SP(futilityreversedepthfactor, 70);
     searchparam SP(futilityreverseimproved, 20);
-    searchparam SP(futilitymargin, 7);
-    searchparam SP(futilitymarginperdepth, 70);
+    searchparam SP(futilitymargin, 10);
+    searchparam SP(futilitymarginperdepth, 59);
     // null move
     searchparam SP(nmmindepth, 2);
     searchparam SP(nmmredbase, 4);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,8 +72,8 @@ struct searchparamset {
     searchparam SP(futilitymindepth, 8);
     searchparam SP(futilityreversedepthfactor, 70);
     searchparam SP(futilityreverseimproved, 20);
-    searchparam SP(futilitymargin, 100);
-    searchparam SP(futilitymarginperdepth, 80);
+    searchparam SP(futilitymargin, 7);
+    searchparam SP(futilitymarginperdepth, 70);
     // null move
     searchparam SP(nmmindepth, 2);
     searchparam SP(nmmredbase, 4);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,8 +72,8 @@ struct searchparamset {
     searchparam SP(futilitymindepth, 8);
     searchparam SP(futilityreversedepthfactor, 70);
     searchparam SP(futilityreverseimproved, 20);
-    searchparam SP(futilitymargin, 100);
-    searchparam SP(futilitymarginperdepth, 80);
+    searchparam SP(futilitymargin, 150);
+    searchparam SP(futilitymarginperdepth, 120);
     // null move
     searchparam SP(nmmindepth, 2);
     searchparam SP(nmmredbase, 4);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,8 +72,8 @@ struct searchparamset {
     searchparam SP(futilitymindepth, 8);
     searchparam SP(futilityreversedepthfactor, 70);
     searchparam SP(futilityreverseimproved, 20);
-    searchparam SP(futilitymargin, 150);
-    searchparam SP(futilitymarginperdepth, 120);
+    searchparam SP(futilitymargin, 436);
+    searchparam SP(futilitymarginperdepth, 0);
     // null move
     searchparam SP(nmmindepth, 2);
     searchparam SP(nmmredbase, 4);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -72,8 +72,8 @@ struct searchparamset {
     searchparam SP(futilitymindepth, 8);
     searchparam SP(futilityreversedepthfactor, 70);
     searchparam SP(futilityreverseimproved, 20);
-    searchparam SP(futilitymargin, 10);
-    searchparam SP(futilitymarginperdepth, 59);
+    searchparam SP(futilitymargin, 100);
+    searchparam SP(futilitymarginperdepth, 80);
     // null move
     searchparam SP(nmmindepth, 2);
     searchparam SP(nmmredbase, 4);
@@ -560,7 +560,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     }
 
     // futility pruning
-    bool futility = false;
+    //bool futility = false;
     if (Pt != NoPrune && depth <= sps.futilitymindepth)
     {
         // reverse futility pruning
@@ -570,7 +570,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             SDEBUGDO(isDebugPv, pvabortval[ply] = staticeval; pvaborttype[ply] = PVA_REVFUTILITYPRUNED;);
             return staticeval;
         }
-        futility = (staticeval < alpha - (sps.futilitymargin + sps.futilitymarginperdepth * depth));
+        //futility = (staticeval < alpha - (sps.futilitymargin + sps.futilitymarginperdepth * depth));
     }
 
     // Nullmove pruning with verification like SF does it
@@ -682,15 +682,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             continue;
         }
 
-        // Check for futility pruning condition for this move and skip move if at least one legal move is already found
-        bool futilityPrune = futility && !ISTACTICAL(mc) && !isCheckbb && alpha <= 900 && !moveGivesCheck(mc);
-        if (futilityPrune && legalMoves)
-        {
-            STATISTICSINC(moves_pruned_futility);
-            SDEBUGDO(isDebugMove, pvaborttype[ply] = PVA_FUTILITYPRUNED;);
-            continue;
-        }
-
         // Prune moves with bad SEE
         if (Pt != NoPrune 
             && !isCheckbb
@@ -775,9 +766,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
         }
         
-        if (!playMove(mc))
-            continue;
-
         // Late move reduction
         int reduction = 0;
         if (depth >= sps.lmrmindepth)
@@ -796,7 +784,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
                 reduction -= (PVNode && (!tpHit || hashmovecode != (uint16_t)mc || hashscore > alpha));
 
                 // adjust reduction with opponents move number
-                reduction -= (CurrentMoveNum[ply - 1] >= sps.lmropponentmovecount);
+                reduction -= (CurrentMoveNum[ply] >= sps.lmropponentmovecount);
 
                 STATISTICSINC(red_pi[positionImproved]);
                 STATISTICSADD(red_lmr[positionImproved], reductiontable[positionImproved][depth][min(63, legalMoves + 1)]);
@@ -813,6 +801,19 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
         }
         effectiveDepth = depth + extendall - reduction + extendMove;
+
+        // Check for futility pruning condition for this move and skip move if at least one legal move is already found
+        bool futility = (effectiveDepth <= sps.futilitymindepth && staticeval < alpha - (sps.futilitymargin + sps.futilitymarginperdepth * effectiveDepth));
+        bool futilityPrune = futility && !ISTACTICAL(mc) && !isCheckbb && alpha <= 900 && !moveGivesCheck(mc);
+        if (legalMoves && futilityPrune)
+        {
+            STATISTICSINC(moves_pruned_futility);
+            SDEBUGDO(isDebugMove, pvaborttype[ply] = PVA_FUTILITYPRUNED;);
+            continue;
+        }
+
+        if (!playMove(mc))
+            continue;
 
         SDEBUGDO(isDebugMove, debugMovePlayed = true;);
         STATISTICSINC(moves_played[(bool)ISTACTICAL(mc)]);


### PR DESCRIPTION
STC:
ELO   | 5.17 +- 3.56 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10696 W: 1651 L: 1492 D: 7553

LTC:
ELO   | 4.44 +- 2.81 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 10952 W: 1098 L: 958 D: 8896
