### PR TITLE
Moveorder

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1220,6 +1220,7 @@ struct chessmovestack
     int lastnullmove;
     uint32_t movecode;
     U64 kingPinned;
+    unsigned int threatSquare;
 };
 
 #define MAXMOVELISTLENGTH 256   // for lists of possible pseudo-legal moves
@@ -1376,6 +1377,7 @@ public:
     int lastnullmove;
     uint32_t movecode;
     U64 kingPinned;
+    unsigned int threatSquare;
 
     uint8_t mailbox[BOARDSIZE]; // redundand for faster "which piece is on field x"
     chessmovestack prerootmovestack[PREROOTMOVES];   // moves before root since last halfmovescounter reset
@@ -1444,7 +1446,6 @@ public:
     int16_t counterhistory[14][64][14 * 64];
     int16_t tacticalhst[7][64][6];
     uint32_t countermove[14][64];
-    int threatSquare;
     int he_threshold;
     U64 he_yes;
     U64 he_all;

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1361,6 +1361,7 @@ public:
     U64 piece00[14];
     U64 attackedBy2[2];
     U64 attackedBy[2][7];
+    U64 threats;
 
     // The following block is mapped/copied to the movestack, so its important to keep the order
     int state;
@@ -1439,10 +1440,11 @@ public:
 #endif
 
     // The following part of the chessposition object isn't copied from rootposition object to the threads positions
-    int16_t history[2][64][64];
+    int16_t history[2][65][64][64];
     int16_t counterhistory[14][64][14 * 64];
     int16_t tacticalhst[7][64][6];
     uint32_t countermove[14][64];
+    int threatSquare;
     int he_threshold;
     U64 he_yes;
     U64 he_all;
@@ -1487,6 +1489,7 @@ public:
     void unplayNullMove();
     U64 nextHash(uint32_t mc);
     template <int Me> void updatePins();
+    template <int Me> void updateThreats();
     template <int Me> bool sliderAttacked(int index, U64 occ);
     bool moveGivesCheck(uint32_t c);  // simple and imperfect as it doesn't handle special moves and cases (mainly to avoid pruning of important moves)
     bool moveIsPseudoLegal(uint32_t c);     // test if move is possible in current position

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1877,6 +1877,7 @@ struct statistic {
     U64 prune_nm;               // nodes pruned by null move;
     U64 prune_probcut;          // nodes pruned by PobCut
     U64 prune_multicut;         // nodes pruned by Multicut (detected by failed singular test)
+    U64 prune_threat;           // nodes pruned by (no opponents) threat
 
     U64 moves_loop_n;           // counts how often the moves loop is entered
     U64 moves_n[2];             // all moves in alphabeta move loop split into quites ans tactical

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -561,6 +561,11 @@ void chessposition::evaluateMoves(chessmovelist *ml)
 void chessposition::getRootMoves()
 {
     chessmovelist movelist;
+    
+    if (state & S2MMASK)
+        updateThreats<BLACK>();
+    else
+        updateThreats<WHITE>();
     prepareStack();
     movelist.length = CreateMovelist<ALL>(&movelist.move[0]);
     evaluateMoves<ALL>(&movelist);
@@ -955,7 +960,7 @@ template <int Me> void chessposition::updateThreats()
     threatsByRooks &= piece00[WQUEEN | Me];
 
     threats = threatsByPawns | threatsByMinors | threatsByRooks;
-    if (threats)
+    if (0 && threats)
         GETLSB(threatSquare, threats);
     else
         threatSquare = 64;

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -960,7 +960,7 @@ template <int Me> void chessposition::updateThreats()
     threatsByRooks &= piece00[WQUEEN | Me];
 
     threats = threatsByPawns | threatsByMinors | threatsByRooks;
-    if (0 && threats)
+    if (threats)
         GETLSB(threatSquare, threats);
     else
         threatSquare = 64;

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -584,7 +584,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     if (Pt != NoPrune && depth <= sps.futilitymindepth)
     {
         // reverse futility pruning
-        if (!isCheckbb && staticeval - depth * (sps.futilityreversedepthfactor - sps.futilityreverseimproved * positionImproved) > beta)
+        if (!isCheckbb && POPCOUNT(threats) < 2 && staticeval - depth * (sps.futilityreversedepthfactor - sps.futilityreverseimproved * positionImproved) > beta)
         {
             STATISTICSINC(prune_futility);
             SDEBUGDO(isDebugPv, pvabortscore[ply] = staticeval; pvaborttype[ply] = PVA_REVFUTILITYPRUNED;);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -584,7 +584,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
     // Nullmove pruning with verification like SF does it
     int bestknownscore = (hashscore != NOSCORE ? hashscore : staticeval);
-    if (!isCheckbb && depth >= sps.nmmindepth && bestknownscore >= beta && (Pt != MatePrune || beta > -SCORETBWININMAXPLY) && (ply  >= nullmoveply || ply % 2 != nullmoveside) && phcount)
+    if (!isCheckbb && !threats && depth >= sps.nmmindepth && bestknownscore >= beta && (Pt != MatePrune || beta > -SCORETBWININMAXPLY) && (ply  >= nullmoveply || ply % 2 != nullmoveside) && phcount)
     {
         playNullMove();
         int nmreduction = min(depth, sps.nmmredbase + (depth / sps.nmmreddepthratio) + (bestknownscore - beta) / sps.nmmredevalratio + !PVNode * sps.nmmredpvfactor);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -520,7 +520,6 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     if (isCheckbb)
     {
         extendall = 1;
-        threatSquare = 64;
     }
     else {
         if (state & S2MMASK)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -568,6 +568,10 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         }
     }
 
+    // Koivisto idea (no opponents) threat pruning
+    if (!PVNode && !isCheckbb && depth == 1 && staticeval > beta + (positionImproved ? 0 : 30) && !threats)
+        return beta;
+
     // futility pruning
     bool futility = false;
     if (Pt != NoPrune && depth <= sps.futilitymindepth)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -84,6 +84,10 @@ struct searchparamset {
     //Probcut
     searchparam SP(probcutmindepth, 5);
     searchparam SP(probcutmargin, 100);
+    // Threat pruning
+    searchparam SP(threatprunemargin, 30);
+    searchparam SP(threatprunemarginimprove, 0);
+
     // No hashmovereduction
     searchparam SP(nohashreductionmindepth, 3);
     // SEE prune
@@ -569,8 +573,11 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
     }
 
     // Koivisto idea (no opponents) threat pruning
-    if (!PVNode && !isCheckbb && depth == 1 && staticeval > beta + (positionImproved ? 0 : 30) && !threats)
+    if (!PVNode && !isCheckbb && depth == 1 && staticeval > beta + (positionImproved ? sps.threatprunemarginimprove : sps.threatprunemargin) && !threats)
+    {
+        STATISTICSINC(prune_threat);
         return beta;
+    }
 
     // futility pruning
     bool futility = false;
@@ -1780,8 +1787,9 @@ void search_statistics()
     f1 = 100.0 * statistics.prune_nm / (double)n;
     f2 = 100.0 * statistics.prune_probcut / (double)n;
     f3 = 100.0 * statistics.prune_multicut / (double)n;
-    f4 = 100.0 * (statistics.prune_futility + statistics.prune_nm + statistics.prune_probcut + statistics.prune_multicut) / (double)n;
-    printf("(ST) Node pruning            %%Futility: %5.2f   %%NullMove: %5.2f   %%ProbeC.: %5.2f   %%MultiC.: %7.5f Total:  %5.2f\n", f0, f1, f2, f3, f4);
+    f4 = 100.0 * statistics.prune_threat / (double)n;
+    f5 = 100.0 * (statistics.prune_futility + statistics.prune_nm + statistics.prune_probcut + statistics.prune_multicut + statistics.prune_threat) / (double)n;
+    printf("(ST) Node pruning            %%Futility: %5.2f   %%NullMove: %5.2f   %%ProbeC.: %5.2f   %%MultiC.: %7.5f   %%Threat.: %7.5f Total:  %5.2f\n", f0, f1, f2, f3, f4, f5);
 
     // move statistics
     i1 = statistics.moves_n[0]; // quiet moves


### PR DESCRIPTION
STC:
ELO   | 2.90 +- 2.30 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 24408 W: 3515 L: 3311 D: 17582

LTC:
ELO   | 2.08 +- 1.64 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 30664 W: 2821 L: 2637 D: 25206
