### PR TITLE
Movestogo

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1545,7 +1545,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         int timeforallmoves = timetouse + en.movestogo * timeinc;
         if (complete)
             en.endtime1 = startTime + timeforallmoves * en.frequency * f1 / (en.movestogo + 1) / 10000;
-        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / 19) * en.frequency / 1000;
+        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  3 * movevariation)) * en.frequency / 1000;
     }
     else if (timetouse) {
         if (timeinc)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1540,7 +1540,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         // f2: stop immediately at 1.9...3.1 x average movetime
         // movevariation: many moves to go decrease f1 (stop soon)
         int movevariation = min(32, en.movestogo) * 3 / 32;
-        int f1 = max(10 - movevariation, 22 - movevariation - constance);
+        int f1 = max(9 - movevariation, 21 - movevariation - constance);
         int f2 = max(19, 31 - constance);
         int timeforallmoves = timetouse + en.movestogo * timeinc;
         if (complete)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1545,7 +1545,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         int timeforallmoves = timetouse + en.movestogo * timeinc;
         if (complete)
             en.endtime1 = startTime + timeforallmoves * en.frequency * f1 / (en.movestogo + 1) / 10000;
-        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  5 * movevariation)) * en.frequency / 1000;
+        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  4 * movevariation)) * en.frequency / 1000;
     }
     else if (timetouse) {
         if (timeinc)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1545,7 +1545,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         int timeforallmoves = timetouse + en.movestogo * timeinc;
         if (complete)
             en.endtime1 = startTime + timeforallmoves * en.frequency * f1 / (en.movestogo + 1) / 10000;
-        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / 10) * en.frequency / 1000;
+        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / 19) * en.frequency / 1000;
     }
     else if (timetouse) {
         if (timeinc)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1545,7 +1545,7 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         int timeforallmoves = timetouse + en.movestogo * timeinc;
         if (complete)
             en.endtime1 = startTime + timeforallmoves * en.frequency * f1 / (en.movestogo + 1) / 10000;
-        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  3 * movevariation)) * en.frequency / 1000;
+        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  5 * movevariation)) * en.frequency / 1000;
     }
     else if (timetouse) {
         if (timeinc)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1540,12 +1540,12 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         // f2: stop immediately at 1.9...3.1 x average movetime
         // movevariation: many moves to go decrease f1 (stop soon)
         int movevariation = min(32, en.movestogo) * 3 / 32;
-        int f1 = max(9 - movevariation, 21 - movevariation - constance);
+        int f1 = max(11 - movevariation, 23 - movevariation - constance);
         int f2 = max(19, 31 - constance);
         int timeforallmoves = timetouse + en.movestogo * timeinc;
         if (complete)
             en.endtime1 = startTime + timeforallmoves * en.frequency * f1 / (en.movestogo + 1) / 10000;
-        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  4 * movevariation)) * en.frequency / 1000;
+        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  3 * movevariation)) * en.frequency / 1000;
     }
     else if (timetouse) {
         if (timeinc)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1540,12 +1540,12 @@ void resetEndTime(U64 startTime, int constantRootMoves, bool complete)
         // f2: stop immediately at 1.9...3.1 x average movetime
         // movevariation: many moves to go decrease f1 (stop soon)
         int movevariation = min(32, en.movestogo) * 3 / 32;
-        int f1 = max(11 - movevariation, 23 - movevariation - constance);
+        int f1 = max(9 - movevariation, 21 - movevariation - constance);
         int f2 = max(19, 31 - constance);
         int timeforallmoves = timetouse + en.movestogo * timeinc;
         if (complete)
             en.endtime1 = startTime + timeforallmoves * en.frequency * f1 / (en.movestogo + 1) / 10000;
-        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  3 * movevariation)) * en.frequency / 1000;
+        en.endtime2 = startTime + min(max(0, timetouse - overhead), f2 * timeforallmoves / (en.movestogo + 1) / (19 -  4 * movevariation)) * en.frequency / 1000;
     }
     else if (timetouse) {
         if (timeinc)


### PR DESCRIPTION
40/20.0:
ELO   | 29.33 +- 9.71 (95%)
SPRT  | 40/20.0+0.00s Threads=1 Hash=16MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 1496 W: 292 L: 166 D: 1038

40/60.0:
ELO   | 0.06 +- 1.29 (95%)
SPRT  | 40/60.0+0.00s Threads=1 Hash=64MB
LLR   | -2.94 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 50872 W: 4654 L: 4645 D: 41573

Thie black reverse peaks at move 40 and move 80 in the following picture (move time of master) gives an idea on the problem that this patch fixes.
![image](https://user-images.githubusercontent.com/3756180/158376135-b3f36503-988e-43b0-8444-509b83ac9e43.png)
