### PR TITLE
New net nn-b1c332ae1d-20220613.nnue

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #define VERNUMLEGACY 2022
-#define NNUEDEFAULT nn-d3b95fbbeb-20220524.nnue
+#define NNUEDEFAULT nn-b1c332ae1d-20220613.nnue
 
 // Enable to get statistical values about various search features
 //#define STATISTICS


### PR DESCRIPTION
b1c33 vs. 6b0c3
STC:
ELO   | 10.40 +- 6.44 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 5616 W: 1498 L: 1330 D: 2788

LTC:
ELO   | 3.24 +- 2.59 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 33688 W: 8363 L: 8049 D: 17276

6b0c3 vs. d3b95
STC:
ELO   | 12.14 +- 7.16 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 4752 W: 1331 L: 1165 D: 2256

LTC:
ELO   | 5.66 +- 4.27 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 12648 W: 3258 L: 3052 D: 6338
