### PR TITLE
Fasternn

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -680,6 +680,9 @@ void GetStackWalk(chessposition *pos, const char* message, const char* _File, in
 //
 #define NNUEDEFAULTSTR TOSTRING(NNUEDEFAULT)
 
+// enable this switch for faster SSE2 code using 16bit integers
+#define FASTSSE2
+
 enum NnueType { NnueDisabled = 0, NnueRotate, NnueFlip };
 // The following constants were introduced in original NNUE port from Shogi
 #define NNUEFILEVERSIONROTATE   0x7AF32F16u
@@ -702,8 +705,15 @@ const int NnueHidden1Dims = 32;
 const int NnueHidden2Dims = 32;
 const int NnueClippingShift = 6;
 
+#if defined(USE_SSE2) && !defined(USE_SSSE3) && defined FASTSSE2
+// for native SSE2 platforms we have faster intrinsics for 16bit integers
+#define USE_FASTSSE2
+typedef int16_t weight_t;
+typedef int16_t clipped_t;
+#else
 typedef int8_t weight_t;
 typedef int8_t clipped_t;
+#endif
 
 // All pieces besides kings are inputs => 30 dimensions
 typedef struct {

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -20,6 +20,9 @@
 #define VERNUMLEGACY 2022
 #define NNUEDEFAULT nn-b1c332ae1d-20220613.nnue
 
+// enable this switch for faster SSE2 code using 16bit integers
+#define FASTSSE2
+
 // Enable to get statistical values about various search features
 //#define STATISTICS
 
@@ -679,9 +682,6 @@ void GetStackWalk(chessposition *pos, const char* message, const char* _File, in
 // NNUE stuff
 //
 #define NNUEDEFAULTSTR TOSTRING(NNUEDEFAULT)
-
-// enable this switch for faster SSE2 code using 16bit integers
-#define FASTSSE2
 
 enum NnueType { NnueDisabled = 0, NnueRotate, NnueFlip };
 // The following constants were introduced in original NNUE port from Shogi

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -33,7 +33,7 @@
 //#define EVALTUNE
 
 // Enable this to expose the evaluation and NNUE parameters as UCI options
-#define EVALOPTIONS
+//#define EVALOPTIONS
 
 // Enable this to expose the search parameters as UCI options
 //#define SEARCHOPTIONS

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -772,11 +772,11 @@ public:
     uint32_t GetHash();
 };
 
+template <unsigned int dims>
 class NnueClippedRelu : public NnueLayer
 {
 public:
-    int dims;
-    NnueClippedRelu(NnueLayer* prev, int d);
+    NnueClippedRelu(NnueLayer* prev);
     virtual ~NnueClippedRelu() {};
     bool ReadWeights(NnueNetsource_t is);
 #ifdef EVALOPTIONS
@@ -800,16 +800,14 @@ public:
     uint32_t GetHash();
 };
 
+template <unsigned int inputdims, unsigned int outputdims>
 class NnueNetworkLayer : public NnueLayer
 {
 public:
-    unsigned int inputdims;
-    unsigned int outputdims;
-
     int32_t* bias;
     weight_t* weight;
 
-    NnueNetworkLayer(NnueLayer* prev, int id, int od);
+    NnueNetworkLayer(NnueLayer* prev);
     virtual ~NnueNetworkLayer();
     bool ReadWeights(NnueNetsource_t is);
 #ifdef EVALOPTIONS

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -47,6 +47,12 @@
 // Enable this to enable NNUE debug output
 //#define NNUEDEBUG
 
+#if 0
+#undef USE_AVX512
+#undef USE_AVX2
+#undef USE_SSSE3
+#undef USE_SSE2
+#endif
 
 #ifdef FINDMEMORYLEAKS
 #define _CRTDBG_MAP_ALLOC

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -33,7 +33,7 @@
 //#define EVALTUNE
 
 // Enable this to expose the evaluation and NNUE parameters as UCI options
-#define EVALOPTIONS
+//#define EVALOPTIONS
 
 // Enable this to expose the search parameters as UCI options
 //#define SEARCHOPTIONS
@@ -46,8 +46,6 @@
 
 // Enable this to enable NNUE debug output
 //#define NNUEDEBUG
-#undef USE_AVX2
-//#undef USE_SSSE3
 
 
 #ifdef FINDMEMORYLEAKS

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -767,10 +767,15 @@ public:
     NnueFeatureTransformer();
     virtual ~NnueFeatureTransformer();
     bool ReadFeatureWeights(NnueNetsource_t is);
-    bool ReadWeights(NnueNetsource_t is) { return true; }
+    bool ReadWeights(NnueNetsource_t is) {
+        if (previous) return previous->ReadWeights(is);
+        return true;
+    }
 #ifdef EVALOPTIONS
     void WriteFeatureWeights(ofstream *os);
-    void WriteWeights(ofstream* os) {}
+    void WriteWeights(ofstream* os) {
+        if (previous) return previous->WriteWeights(os);
+    }
 #endif
     uint32_t GetFtHash();
     uint32_t GetHash();

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -57,13 +57,11 @@ NnueType NnueReady = NnueDisabled;
 
 // The network architecture
 NnueFeatureTransformer<NnueFtHalfdims, NnueFtInputdims> NnueFt;
-//NnueInputSlice NnueIn;
 NnueNetworkLayer<NnueFtOutputdims, NnueHidden1Dims> NnueHd1(&NnueFt);
 NnueClippedRelu<NnueHidden1Dims> NnueCl1(&NnueHd1);
 NnueNetworkLayer<NnueHidden1Dims, NnueHidden2Dims> NnueHd2(&NnueCl1);
 NnueClippedRelu<NnueHidden2Dims> NnueCl2(&NnueHd2);
 NnueNetworkLayer<NnueHidden2Dims, 1> NnueOut(&NnueCl2);
-
 
 
 //

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -120,7 +120,7 @@ typedef __m128i sml_vec_t;
 #ifdef USE_AVX512
 #define NUM_REGS 8
 #define SIMD_WIDTH 512
-typedef __m512i ft_vec_t, in_vec_t, acc_vec_t, weight_vec_t, ft_vec_t;
+typedef __m512i ft_vec_t, ftout_vec_t, in_vec_t, acc_vec_t, weight_vec_t, ft_vec_t;
 typedef __m128i bias_vec_t;
 #define vec_zero _mm512_setzero_si512()
 #define vec_add_16(a,b) _mm512_add_epi16(a,b)
@@ -135,7 +135,7 @@ typedef __m128i bias_vec_t;
 #elif defined(USE_AVX2)
 #define NUM_REGS 16
 #define SIMD_WIDTH 256
-typedef __m256i ft_vec_t, in_vec_t, acc_vec_t, weight_vec_t;
+typedef __m256i ft_vec_t, ftout_vec_t, in_vec_t, acc_vec_t, weight_vec_t;
 typedef __m128i bias_vec_t;
 #define vec_zero _mm256_setzero_si256()
 #define vec_add_16(a,b) _mm256_add_epi16(a,b)
@@ -157,13 +157,13 @@ typedef __m128i bias_vec_t;
 #elif defined(USE_SSE2)
 #define NUM_REGS 16
 #define SIMD_WIDTH 128
-typedef __m128i ft_vec_t;
+typedef __m128i ft_vec_t, ftout_vec_t;
 #define k0x80s _mm_set1_epi8(-128)
 #define vec_add_16(a,b) _mm_add_epi16(a,b)
 #define vec_sub_16(a,b) _mm_sub_epi16(a,b)
 #define vec_packs(a,b) _mm_packs_epi16(a,b)
 #if defined(USE_SSSE3)
-typedef __m128i ft_vec_t, in_vec_t, acc_vec_t, weight_vec_t, bias_vec_t;
+typedef __m128i ft_vec_t, ftout_vec_t, in_vec_t, acc_vec_t, weight_vec_t, bias_vec_t;
 #define vec_zero _mm_setzero_si128()
 #define vec_clip_8(a,b) vec_packs(_mm_max_epi16(a,_mm_setzero_si128()),_mm_max_epi16(b,_mm_setzero_si128()))
 #define vec_add_dpbusd_32x2_large Simd::m128_add_dpbusd_32x2
@@ -178,6 +178,7 @@ typedef __m128i ft_vec_t, in_vec_t, acc_vec_t, weight_vec_t, bias_vec_t;
 #define NUM_REGS 16
 #define SIMD_WIDTH 128
 typedef int16x8_t ft_vec_t;
+typedef int8x16_t ftout_vec_t;
 #define vec_add_16(a,b) vaddq_s16(a,b)
 #define vec_sub_16(a,b) vsubq_s16(a,b)
 #define vec_packs(a,b) vcombine_s8(vqmovn_s16(a),vqmovn_s16(b))
@@ -350,7 +351,7 @@ template <NnueType Nt> void chessposition::Transform(clipped_t *output)
 #ifdef USE_SIMD
         constexpr unsigned int numChunks = (16 * NnueFtHalfdims) / SIMD_WIDTH;
 
-        ft_vec_t* out = (ft_vec_t*)&output[offset];
+        ftout_vec_t* out = (ftout_vec_t*)&output[offset];
 
         for (unsigned int i = 0; i < numChunks / 2; i++) {
             ft_vec_t s0 = acc[i * 2];


### PR DESCRIPTION
Some rewrite on the NNUE code using some of the latest SF intrinsics code which gives a solid 1-3% speed gain for x86 (more for Clang, less for gcc) and even > 10% for ARM/Nano (tested an a Rpi2).