### PR TITLE
Uci

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1023,7 +1023,7 @@ public:
     void clean();
     void addHash(U64 hash, int val, int16_t staticeval, int bound, int depth, uint16_t movecode);
     void printHashentry(U64 hash);
-    int probeHash(U64 hash, int *val, int *staticeval, uint16_t *movecode, int depth, int alpha, int beta, int ply);
+    template <bool qsprobe> int probeHash(U64 hash, int *val, int *staticeval, uint16_t *movecode, int depth, int alpha, int beta, int ply);
     uint16_t getMoveCode(U64 hash);
     unsigned int getUsedinPermill();
     void nextSearch() { numOfSearchShiftTwo = (numOfSearchShiftTwo + 4) & 0xfc; }

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1023,7 +1023,7 @@ public:
     void clean();
     void addHash(U64 hash, int val, int16_t staticeval, int bound, int depth, uint16_t movecode);
     void printHashentry(U64 hash);
-    bool probeHash(U64 hash, int *val, int *staticeval, uint16_t *movecode, int depth, int alpha, int beta, int ply);
+    int probeHash(U64 hash, int *val, int *staticeval, uint16_t *movecode, int depth, int alpha, int beta, int ply);
     uint16_t getMoveCode(U64 hash);
     unsigned int getUsedinPermill();
     void nextSearch() { numOfSearchShiftTwo = (numOfSearchShiftTwo + 4) & 0xfc; }
@@ -1616,7 +1616,7 @@ public:
     void getScaling(Materialhashentry *mhentry);
     int getComplexity(int eval, pawnhashentry *phentry, Materialhashentry *mhentry);
 
-    template <RootsearchType RT> int rootsearch(int alpha, int beta, int depth, int inWindowLast, int maxmoveindex = 0);
+    template <RootsearchType RT> int rootsearch(int alpha, int beta, int *depth, int inWindowLast, int maxmoveindex = 0);
     template <PruneType Pt> int alphabeta(int alpha, int beta, int depth);
     template <PruneType Pt> int getQuiescence(int alpha, int beta, int depth);
     void updateHistory(uint32_t code, int value);

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -2115,6 +2115,7 @@ public:
     int index;
     int depth;
     int lastCompleteDepth;
+    U64 nps;
 #ifdef NNUELEARN
     PackedSfenValue* psvbuffer;
     PackedSfenValue* psv;

--- a/src/learn.cpp
+++ b/src/learn.cpp
@@ -1140,7 +1140,7 @@ SKIP_SAVE:
                         pos->getRootMoves();
                         int cur_multi_pv = min(pos->rootmovelist.length, (ply < random_opening_ply ? 8 : random_multi_pv));
                         int cur_multi_pv_diff = (ply < random_opening_ply ? 100 : random_multi_pv_diff);
-                        pos->rootsearch<MultiPVSearch>(SCOREBLACKWINS, SCOREWHITEWINS, random_multi_pv_depth, 1, cur_multi_pv);
+                        pos->rootsearch<MultiPVSearch>(SCOREBLACKWINS, SCOREWHITEWINS, &random_multi_pv_depth, 1, cur_multi_pv);
                         int s = min(pos->rootmovelist.length, cur_multi_pv);
                         // Exclude moves with score outside of allowed margin
                         while (cur_multi_pv_diff && pos->bestmovescore[0] > pos->bestmovescore[s - 1] + cur_multi_pv_diff)

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -210,7 +210,7 @@ void chessposition::getRootMoves()
     bool bImmediate3fold = false;
     int ttscore, tteval;
     uint16_t tthashmovecode;
-    bool tthit = tp.probeHash(hash, &ttscore, &tteval, &tthashmovecode, 0, SHRT_MIN + 1, SHRT_MAX, 0);
+    bool tthit = tp.probeHash<false>(hash, &ttscore, &tteval, &tthashmovecode, 0, SHRT_MIN + 1, SHRT_MAX, 0);
     bool bSearchmoves = (en.searchmoves.size() > 0);
 
     excludemovestack[0] = 0; // FIXME: Not very nice; is it worth to do do singular testing in root search?

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1210,19 +1210,20 @@ static void uciScore(searchthread *thr, int inWindow, U64 nowtime, int score, in
     en.lastReport = msRun;
     string pvstring = pos->getPv(mpvIndex ? pos->multipvtable[mpvIndex] : pos->lastpv);
     U64 nodes = en.getTotalNodes();
-    U64 nps = (nowtime == en.thinkstarttime) ? 1 : nodes / 1024 * en.frequency / (nowtime - en.thinkstarttime) * 1024;  // lower resolution to avoid overflow under Linux in high performance systems
+    if (msRun > 100)
+        thr->nps = nodes * en.frequency / (nowtime + 1 - en.thinkstarttime);  // lower resolution to avoid overflow under Linux in high performance systems
 
     if (!MATEDETECTED(score))
     {
         guiCom << "info depth " + to_string(thr->depth) + " seldepth " + to_string(pos->seldepth) + " multipv " + to_string(mpvIndex + 1) + " time " + to_string(msRun)
-            + " score cp " + to_string(score) + " " + boundscore[inWindow] + "nodes " + to_string(nodes) + " nps " + to_string(nps) + " tbhits " + to_string(en.tbhits)
+            + " score cp " + to_string(score) + " " + boundscore[inWindow] + "nodes " + to_string(nodes) + " nps " + to_string(thr->nps) + " tbhits " + to_string(en.tbhits)
             + " hashfull " + to_string(tp.getUsedinPermill()) + " pv " + pvstring + "\n";
     }
     else
     {
         int matein = MATEIN(score);
         guiCom << "info depth " + to_string(thr->depth) + " seldepth " + to_string(pos->seldepth) + " multipv " + to_string(mpvIndex + 1) + " time " + to_string(msRun)
-            + " score mate " + to_string(matein) + " " + boundscore[inWindow] + "nodes " + to_string(nodes) + " nps " + to_string(nps) + " tbhits " + to_string(en.tbhits)
+            + " score mate " + to_string(matein) + " " + boundscore[inWindow] + "nodes " + to_string(nodes) + " nps " + to_string(thr->nps) + " tbhits " + to_string(en.tbhits)
             + " hashfull " + to_string(tp.getUsedinPermill()) + " pv " + pvstring + "\n";
     }
     SDEBUGDO(pos->pvmovecode[0], guiCom.log("[SDEBUG] Raw score: " + to_string(score) + "\n"););

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1210,7 +1210,8 @@ static void uciScore(searchthread *thr, int inWindow, U64 nowtime, int score, in
     en.lastReport = msRun;
     string pvstring = pos->getPv(mpvIndex ? pos->multipvtable[mpvIndex] : pos->lastpv);
     U64 nodes = en.getTotalNodes();
-    if (msRun > 100)
+
+    if (nodes)
         thr->nps = nodes * en.frequency / (nowtime + 1 - en.thinkstarttime);  // lower resolution to avoid overflow under Linux in high performance systems
 
     if (!MATEDETECTED(score))

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -196,7 +196,7 @@ int chessposition::getQuiescence(int alpha, int beta, int depth)
     int hashscore = NOSCORE;
     uint16_t hashmovecode = 0;
     int staticeval = NOSCORE;
-    bool tpHit = tp.probeHash(hash, &hashscore, &staticeval, &hashmovecode, depth, alpha, beta, ply);
+    bool tpHit = tp.probeHash<true>(hash, &hashscore, &staticeval, &hashmovecode, depth, alpha, beta, ply);
     if (tpHit)
     {
         STATISTICSINC(qs_tt);
@@ -408,7 +408,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 #endif
 
     // TT lookup
-    bool tpHit = tp.probeHash(newhash, &hashscore, &staticeval, &hashmovecode, depth, alpha, beta, ply);
+    bool tpHit = tp.probeHash<false>(newhash, &hashscore, &staticeval, &hashmovecode, depth, alpha, beta, ply);
     if (tpHit && !rep && !PVNode)
     {
         if (hashscore >= beta && hashmovecode && !mailbox[GETTO(hashmovecode)])
@@ -689,7 +689,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             if ((mc & 0xffff) == hashmovecode
                 && depth >= sps.singularmindepth
                 && !excludeMove
-                && tp.probeHash(newhash, &hashscore, &staticeval, &hashmovecode, depth - 3, alpha, beta, ply)  // FIXME: maybe needs hashscore = FIXMATESCOREPROBE(hashscore, ply);
+                && tp.probeHash<false>(newhash, &hashscore, &staticeval, &hashmovecode, depth - 3, alpha, beta, ply)  // FIXME: maybe needs hashscore = FIXMATESCOREPROBE(hashscore, ply);
                 && hashscore > alpha
 #ifdef NNUELEARN
                 // No singular extension in root of gensfen
@@ -950,7 +950,7 @@ int chessposition::rootsearch(int alpha, int beta, int *depthptr, int inWindowLa
     int newDepth;
     if (!isMultiPV
         && !useRootmoveScore
-        && (newDepth = tp.probeHash(hash, &score, &staticeval, &hashmovecode, depth, alpha, beta, 0)))
+        && (newDepth = tp.probeHash<false>(hash, &score, &staticeval, &hashmovecode, depth, alpha, beta, 0)))
     {
         // Hash is fixed regarding scores that don't see actual 3folds so we can trust the entry
         uint32_t fullhashmove = shortMove2FullMove(hashmovecode);
@@ -1367,7 +1367,7 @@ void mainSearch(searchthread *thr)
                 {
                     uint16_t mc = 0;
                     int dummystaticeval;
-                    tp.probeHash(pos->hash, &score, &dummystaticeval, &mc, MAXDEPTH, alpha, beta, 0);
+                    tp.probeHash<false>(pos->hash, &score, &dummystaticeval, &mc, MAXDEPTH, alpha, beta, 0);
                     pos->bestmove = pos->shortMove2FullMove(mc);
                     pos->pondermove = 0;
                 }

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -288,7 +288,7 @@ void transposition::printHashentry(U64 hash)
 }
 
 
-bool transposition::probeHash(U64 hash, int *val, int *staticeval, uint16_t *movecode, int depth, int alpha, int beta, int ply)
+int transposition::probeHash(U64 hash, int *val, int *staticeval, uint16_t *movecode, int depth, int alpha, int beta, int ply)
 {
 #ifdef EVALTUNE
     // don't use transposition table when tuning evaluation
@@ -306,26 +306,19 @@ bool transposition::probeHash(U64 hash, int *val, int *staticeval, uint16_t *mov
             int bound = (e->boundAndAge & BOUNDMASK);
             int v = FIXMATESCOREPROBE(e->value, ply);
             if (bound == HASHEXACT)
-            {
                 *val = v;
-                return (e->depth >= depth);
-            }
-            if (bound == HASHALPHA && v <= alpha)
-            {
+            else if (bound == HASHALPHA && v <= alpha)
                 *val = alpha;
-                return (e->depth >= depth);
-            }
-            if (bound == HASHBETA && v >= beta)
-            {
+            else if (bound == HASHBETA && v >= beta)
                 *val = beta;
-                return (e->depth >= depth);
-            }
-            // value outside boundary
-            return false;
+            else
+                // value outside boundary
+                return 0;
+            return (e->depth >= depth ? max(1, e->depth) : 0);
         }
     }
     // not found
-    return false;
+    return 0;
 }
 
 

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -288,6 +288,7 @@ void transposition::printHashentry(U64 hash)
 }
 
 
+template <bool qsprobe>
 int transposition::probeHash(U64 hash, int *val, int *staticeval, uint16_t *movecode, int depth, int alpha, int beta, int ply)
 {
 #ifdef EVALTUNE
@@ -314,7 +315,7 @@ int transposition::probeHash(U64 hash, int *val, int *staticeval, uint16_t *move
             else
                 // value outside boundary
                 return 0;
-            return (e->depth >= depth ? max(1, e->depth) : 0);
+            return (qsprobe ? 1 : (e->depth >= depth ? e->depth : 0));
         }
     }
     // not found
@@ -403,3 +404,8 @@ bool  Materialhash::probeHash(U64 hash, Materialhashentry **entry)
 
 
 transposition tp;
+
+// Explicit template instantiation
+// This avoids putting these definitions in header file
+template int transposition::probeHash<true>(U64, int*, int*, uint16_t*, int, int, int, int);
+template int transposition::probeHash<false>(U64, int*, int*, uint16_t*, int, int, int, int);


### PR DESCRIPTION
Improves UCI output:
- Don't repeat output of low depth tt moves
- Avoid output of '0 nps'
```
ELO   | 3.13 +- 4.61 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 11216 W: 2944 L: 2843 D: 5429```