### PR TITLE
Pruning

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -2068,7 +2068,7 @@ struct searchparamset {
     searchparam SP(razormargin, 250);
     searchparam SP(razordepthfactor, 50);
     //futility pruning
-    searchparam SP(futilitymindepth, 8);
+    //searchparam SP(futilitymindepth, 8);
     searchparam SP(futilityreversedepthfactor, 70);
     searchparam SP(futilityreverseimproved, 20);
     searchparam SP(futilitymargin, 10);
@@ -2090,7 +2090,7 @@ struct searchparamset {
     // No hashmovereduction
     searchparam SP(nohashreductionmindepth, 3);
     // SEE prune
-    searchparam SP(seeprunemaxdepth, 8);
+    //searchparam SP(seeprunemaxdepth, 8);
     searchparam SP(seeprunemarginperdepth, -20);
     searchparam SP(seeprunequietfactor, 4);
     // Singular extension

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -2068,7 +2068,6 @@ struct searchparamset {
     searchparam SP(razormargin, 250);
     searchparam SP(razordepthfactor, 50);
     //futility pruning
-    //searchparam SP(futilitymindepth, 8);
     searchparam SP(futilityreversedepthfactor, 70);
     searchparam SP(futilityreverseimproved, 20);
     searchparam SP(futilitymargin, 10);
@@ -2090,7 +2089,6 @@ struct searchparamset {
     // No hashmovereduction
     searchparam SP(nohashreductionmindepth, 3);
     // SEE prune
-    //searchparam SP(seeprunemaxdepth, 8);
     searchparam SP(seeprunemarginperdepth, -20);
     searchparam SP(seeprunequietfactor, 4);
     // Singular extension

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -653,7 +653,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
             }
 
             // Check for futility pruning condition for this move and skip move if at least one legal move is already found
-            bool futilityPrune = futility && !ISTACTICAL(mc) && !isCheckbb && alpha <= 900 && !moveGivesCheck(mc);
+            bool futilityPrune = futility && !ISTACTICAL(mc) && !isCheckbb && !moveGivesCheck(mc);
             if (futilityPrune && legalMoves)
             {
                 STATISTICSINC(moves_pruned_futility);

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -23,9 +23,9 @@ statistic statistics;
 #endif
 
 
-#define MAXLMPDEPTH 9
+#define MAXPRUNINGDEPTH 8
 int reductiontable[2][MAXDEPTH][64];
-int lmptable[2][MAXLMPDEPTH];
+int lmptable[2][MAXPRUNINGDEPTH + 1];
 
 // Shameless copy of Ethereal/Laser for now; may be improved/changed in the future
 static const int SkipSize[16] = { 1, 1, 1, 2, 2, 2, 1, 3, 2, 2, 1, 3, 3, 2, 2, 1 };
@@ -42,7 +42,7 @@ void searchtableinit()
             // reduction for improving positions
             reductiontable[1][d][m] = (int)round(log(d * (sps.lmrlogf1 / 100.0)) * log(m * 2) * (sps.lmrf1 / 100.0));
         }
-    for (int d = 0; d < MAXLMPDEPTH; d++)
+    for (int d = 0; d <= MAXPRUNINGDEPTH; d++)
     {
         // lmp for not improving positions
         lmptable[0][d] = (int)(2.5 + (sps.lmpf0 / 100.0) * round(pow(d, sps.lmppow0 / 100.0)));
@@ -524,7 +524,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
 
     // futility pruning
     bool futility = false;
-    if (Pt != NoPrune && depth <= sps.futilitymindepth)
+    if (Pt != NoPrune && depth <= MAXPRUNINGDEPTH)
     {
         // reverse futility pruning
         if (!isCheckbb && POPCOUNT(threats) < 2 && staticeval - depth * (sps.futilityreversedepthfactor - sps.futilityreverseimproved * positionImproved) > beta)
@@ -639,40 +639,37 @@ int chessposition::alphabeta(int alpha, int beta, int depth)
         if ((mc & 0xffff) == excludeMove)
             continue;
 
-        // Late move pruning
-        if (Pt != NoPrune
-            && depth < MAXLMPDEPTH
-            && !ISTACTICAL(mc)
-            && bestscore > -SCORETBWININMAXPLY
-            && quietsPlayed > lmptable[positionImproved][depth])
+        if (Pt != NoPrune && depth <= MAXPRUNINGDEPTH && bestscore > -SCORETBWININMAXPLY)
         {
-            // Proceed to next moveselector state manually to save some time
-            ms->state++;
-            STATISTICSINC(moves_pruned_lmp);
-            SDEBUGDO(isDebugMove, pvaborttype[ply] = PVA_LMPRUNED;);
-            continue;
-        }
+            // Late move pruning
+            if (!ISTACTICAL(mc)
+                && quietsPlayed > lmptable[positionImproved][depth])
+            {
+                // Proceed to next moveselector state manually to save some time
+                ms->state++;
+                STATISTICSINC(moves_pruned_lmp);
+                SDEBUGDO(isDebugMove, pvaborttype[ply] = PVA_LMPRUNED;);
+                continue;
+            }
 
-        // Check for futility pruning condition for this move and skip move if at least one legal move is already found
-        bool futilityPrune = futility && !ISTACTICAL(mc) && !isCheckbb && alpha <= 900 && !moveGivesCheck(mc);
-        if (futilityPrune && legalMoves)
-        {
-            STATISTICSINC(moves_pruned_futility);
-            SDEBUGDO(isDebugMove, pvaborttype[ply] = PVA_FUTILITYPRUNED;);
-            continue;
-        }
+            // Check for futility pruning condition for this move and skip move if at least one legal move is already found
+            bool futilityPrune = futility && !ISTACTICAL(mc) && !isCheckbb && alpha <= 900 && !moveGivesCheck(mc);
+            if (futilityPrune && legalMoves)
+            {
+                STATISTICSINC(moves_pruned_futility);
+                SDEBUGDO(isDebugMove, pvaborttype[ply] = PVA_FUTILITYPRUNED;);
+                continue;
+            }
 
-        // Prune moves with bad SEE
-        if (Pt != NoPrune
-            && !isCheckbb
-            && depth <= sps.seeprunemaxdepth
-            && bestscore > -SCORETBWININMAXPLY
-            && ms->state >= QUIETSTATE
-            && !see(mc, sps.seeprunemarginperdepth * depth * (ISTACTICAL(mc) ? depth : sps.seeprunequietfactor)))
-        {
-            STATISTICSINC(moves_pruned_badsee);
-            SDEBUGDO(isDebugMove, pvaborttype[ply] = PVA_SEEPRUNED;);
-            continue;
+            // Prune moves with bad SEE
+            if (!isCheckbb
+                && ms->state >= QUIETSTATE
+                && !see(mc, sps.seeprunemarginperdepth * depth * (ISTACTICAL(mc) ? depth : sps.seeprunequietfactor)))
+            {
+                STATISTICSINC(moves_pruned_badsee);
+                SDEBUGDO(isDebugMove, pvaborttype[ply] = PVA_SEEPRUNED;);
+                continue;
+            }
         }
 
         // early prefetch of the next tt entry; valid for normal moves


### PR DESCRIPTION
ELO   | 1.36 +- 3.53 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-4.00, 1.00]
GAMES | N: 19120 W: 4975 L: 4900 D: 9245

Simplifies the conditions for pruning and improves mating tested with matetrack to
```
Total fens:    6566
Found mates:   1769
Best mates:    1195
```
Also fixes output of wrong fail low score when search is interrupted.