### PR TITLE
Fix the pawnful case.

### DIFF
--- a/src/tbcore.c
+++ b/src/tbcore.c
@@ -1184,7 +1184,7 @@ static int init_table_dtz(struct TBEntry *entry)
                 else {
                     data += (uintptr_t)data & 0x01;
                     for (i = 0; i < 4; i++) {
-                        ptr->map_idx[f][i] = (uint16_t)(data + 1 - ptr->map);
+                        ptr->map_idx[f][i] = (uint16_t)((uint16_t*)data + 1 - (uint16_t*)ptr->map);
                         data += 2 + 2 * *(uint16_t*)(data);
                     }
                 }


### PR DESCRIPTION
This makes evaluation of dtz with pawn using wide extension work (forgot to fix this in last commit).
E.g. ```position fen 6B1/3B4/5R2/6q1/P7/1k6/8/3K4 b - -``` will show score of -29244 (-656) when 50 move rule is disabled.