### PR TITLE
Limitnps

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1904,6 +1904,7 @@ public:
     int RatingAdv;
     int ContemptRatio;
     int ResultingContempt;
+    int LimitKnps;
     chessposition rootposition;
     int Threads;
     int oldThreads;

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1904,7 +1904,7 @@ public:
     int RatingAdv;
     int ContemptRatio;
     int ResultingContempt;
-    int LimitKnps;
+    int LimitNps;
     chessposition rootposition;
     int Threads;
     int oldThreads;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -212,6 +212,7 @@ void engine::registerOptions()
     ucioptions.Register(&Contempt, "Contempt", ucispin, "0", -100, 100, uciSetContempt);
     ucioptions.Register(&RatingAdv, "UCI_RatingAdv", ucispin, "0", -10000, 10000, uciSetContempt);
     ucioptions.Register(&ContemptRatio, "ContemptRatio", ucispin, "4", 0, 16, uciSetContempt);
+    ucioptions.Register(&LimitKnps, "LimitKnps", ucispin, "0", 0, INT_MAX, nullptr);
 }
 
 
@@ -571,7 +572,7 @@ void engine::communicate(string inputstring)
                     btime = &mytime;
                     binc = &myinc;
                 }
-                maxnodes = 0ULL;
+                maxnodes = LimitKnps * 1024 / en.Threads;
                 infinite = false;
                 while (ci < cs)
                 {

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -212,7 +212,7 @@ void engine::registerOptions()
     ucioptions.Register(&Contempt, "Contempt", ucispin, "0", -100, 100, uciSetContempt);
     ucioptions.Register(&RatingAdv, "UCI_RatingAdv", ucispin, "0", -10000, 10000, uciSetContempt);
     ucioptions.Register(&ContemptRatio, "ContemptRatio", ucispin, "4", 0, 16, uciSetContempt);
-    ucioptions.Register(&LimitKnps, "LimitKnps", ucispin, "0", 0, INT_MAX, nullptr);
+    ucioptions.Register(&LimitNps, "LimitNps", ucispin, "0", 0, INT_MAX, nullptr);
 }
 
 
@@ -572,7 +572,7 @@ void engine::communicate(string inputstring)
                     btime = &mytime;
                     binc = &myinc;
                 }
-                maxnodes = LimitKnps * 1024 / en.Threads;
+                maxnodes = LimitNps / en.Threads;
                 infinite = false;
                 while (ci < cs)
                 {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -77,16 +77,6 @@ inline bool chessposition::CheckForImmediateStop()
 
         if (waitMs)
             Sleep(waitMs);
-
-        // Check again if time is over cause Sleep is not precise
-        if (en.endtime2) {
-            S64 remainingticks = en.endtime2 - getTime();
-            if (remainingticks <= 0) {
-                en.stopLevel = ENGINESTOPIMMEDIATELY;
-                return true;
-            }
-        }
-        return false;
     }
 
     if (threadindex)
@@ -99,7 +89,7 @@ inline bool chessposition::CheckForImmediateStop()
         // pondering... just continue searching
         return false;
 
-    if (--nodesToNextCheck > 0)
+    if (!en.LimitKnps && --nodesToNextCheck > 0)
         return false;
 
     S64 remainingticks = en.endtime2 - getTime();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -71,7 +71,16 @@ inline bool chessposition::CheckForImmediateStop()
         int AllowedTimeMs = (int)(nodes * 1024 / en.maxnodes);
         int remainingMs = (int)((en.endtime2 - now) * 1000 / en.frequency);
         int waitMs = min(remainingMs, max(0, AllowedTimeMs - thinkingTimeMs));
-        Sleep(waitMs);
+        if (waitMs) {
+            //guiCom << "info string Allowed=" + to_string(AllowedTimeMs) + "  thinking=" + to_string(thinkingTimeMs) + "  remaining=" + to_string(remainingMs) + "\n";
+            //guiCom << "info string Sleeping " + to_string(waitMs) + "\n";
+            Sleep(waitMs);
+            if (en.endtime2 && en.endtime2 - getTime() <= 0) {
+                en.stopLevel = ENGINESTOPIMMEDIATELY;
+                return true;
+            }
+            return false;
+        }
     }
 
     if (threadindex)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -68,6 +68,7 @@ inline bool chessposition::CheckForImmediateStop()
         // Limit nps
         if (en.stopLevel == ENGINESTOPIMMEDIATELY)
             return true;
+        nodesToNextCheck = 0;
         U64 now = getTime();
         int thinkingTimeMs = (int)((S64)(now - en.thinkstarttime) * 1000.0 / en.frequency);
         int AllowedTimeMs = (int)(nodes * 1000.0 / en.maxnodes);
@@ -91,7 +92,7 @@ inline bool chessposition::CheckForImmediateStop()
         // pondering... just continue searching
         return false;
 
-    if (!en.LimitNps && --nodesToNextCheck > 0)
+    if (--nodesToNextCheck > 0)
         return false;
 
     S64 remainingticks = en.endtime2 - getTime();

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -61,14 +61,16 @@ void searchinit()
 inline bool chessposition::CheckForImmediateStop()
 {
     if (en.maxnodes) {
-        if (!en.LimitKnps)
+        if (!en.LimitNps)
             // go nodes
             return (nodes >= en.maxnodes);
         
         // Limit nps
+        if (en.stopLevel == ENGINESTOPIMMEDIATELY)
+            return true;
         U64 now = getTime();
         int thinkingTimeMs = (int)((S64)(now - en.thinkstarttime) * 1000.0 / en.frequency);
-        int AllowedTimeMs = (int)(nodes * 1024 / en.maxnodes);
+        int AllowedTimeMs = (int)(nodes * 1000.0 / en.maxnodes);
         int waitMs = max(0, AllowedTimeMs - thinkingTimeMs);
         if (en.endtime2) {
             int remainingMs = (int)((S64)(en.endtime2 - now) * 1000.0 / en.frequency);
@@ -89,7 +91,7 @@ inline bool chessposition::CheckForImmediateStop()
         // pondering... just continue searching
         return false;
 
-    if (!en.LimitKnps && --nodesToNextCheck > 0)
+    if (!en.LimitNps && --nodesToNextCheck > 0)
         return false;
 
     S64 remainingticks = en.endtime2 - getTime();
@@ -1357,7 +1359,7 @@ void mainSearch(searchthread *thr)
             break;
 
         // exit when max nodes reached
-        if (en.maxnodes && !en.LimitKnps && pos->nodes >= en.maxnodes)
+        if (en.maxnodes && !en.LimitNps && pos->nodes >= en.maxnodes)
             break;
 
         if (pos->pvtable[0][0])
@@ -1512,7 +1514,7 @@ void mainSearch(searchthread *thr)
         ss << "[TDEBUG] stop info last movetime: " << setprecision(3) << (nowtime - en.clockstarttime) / (double)en.frequency << "    full-it. / immediate:  " << en.t1stop << " / " << en.t2stop << "\n";
         guiCom.log(ss.str());
 #endif
-        if (en.maxnodes && !en.LimitKnps)
+        if (en.maxnodes && !en.LimitNps)
         {
             // Wait for helper threads to finish their nodes
             for (int i = 1; i < en.Threads; i++)


### PR DESCRIPTION
Test tourney: Ranking looks good and only one single time forfeit that may be due to some background action on computer and concurrency 32.
```
Rank Name                          Elo     +/-   Games   Score   Draws
   1 limit1m                       527      58     402   95.4%    9.2%
   2 limit512k                     425      51     402   92.0%   10.9%
   3 limit256k                     338      45     400   87.5%   11.5%
   4 limit128k                     262      41     400   81.9%    9.8%
   5 limit64k                      183      38     400   74.1%    5.3%
   6 limit32k                      126      36     402   67.4%    4.0%
   7 limit16k                       64      34     400   59.1%    3.3%
   8 limit8k                        22      34     400   53.1%    3.3%
   9 limit4k                       -36      34     400   44.9%    2.3%
  10 limit2k                       -78      34     402   38.9%    2.2%
  11 limit1k                      -114      35     402   34.2%    2.7%
  12 limit512                     -172      38     400   27.1%    2.8%
  13 limit256                     -228      41     400   21.3%    1.5%
  14 limit128                     -338      52     400   12.5%    0.5%
  15 limit64                      -490      77     400    5.6%    0.3%
  16 limit32                      -522      85     402    4.7%    0.0%
```