### PR TITLE
New default network nn-5e38b8ddf1-20221228.nnue

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #define VERNUMLEGACY 2022
-#define NNUEDEFAULT nn-5e6b321f90-20221001.nnue
+#define NNUEDEFAULT nn-5e38b8ddf1-20221228.nnue
 
 // enable this switch for faster SSE2 code using 16bit integers
 #define FASTSSE2


### PR DESCRIPTION
Step1 (e34b5 vs. master)
STC:
ELO   | 4.72 +- 3.73 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 17208 W: 4579 L: 4345 D: 8284
LTC:
ELO   | 3.67 +- 2.96 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 5.00]
GAMES | N: 27152 W: 7116 L: 6829 D: 13207

Step2 (5e38b vs. e34b5)
STC:
ELO   | 6.00 +- 4.91 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 9904 W: 2644 L: 2473 D: 4787
LTC:
ELO   | 8.22 +- 5.91 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-1.00, 4.00]
GAMES | N: 6768 W: 1808 L: 1648 D: 3312