### PR TITLE
Currentmovenum

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1073,7 +1073,6 @@ int chessposition::rootsearch(int alpha, int beta, int *depthptr, int inWindowLa
         int reduction = 0;
         CurrentMoveNum[1] = i + 1;
 
-
         // Late move reduction
         if (!ISTACTICAL(m->code))
         {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -1071,6 +1071,8 @@ int chessposition::rootsearch(int alpha, int beta, int *depthptr, int inWindowLa
             guiCom << "info depth " + to_string(depth) + " currmove " + m->toString() + " currmovenumber " + to_string(i + 1) + "\n";
 #endif
         int reduction = 0;
+        CurrentMoveNum[1] = i + 1;
+
 
         // Late move reduction
         if (!ISTACTICAL(m->code))


### PR DESCRIPTION
Fix valgrind warning.

STC:
ELO   | 2.05 +- 3.35 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.96 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 21360 W: 5596 L: 5470 D: 10294

LTC:
ELO   | 1.85 +- 3.19 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [-3.00, 1.00]
GAMES | N: 23144 W: 5967 L: 5844 D: 11333

