### PR TITLE
Add a namespace for all code

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -105,6 +105,11 @@
 #undef USE_SIMD
 #endif
 
+using namespace std;
+
+namespace rubichess {
+
+
 #ifdef _WIN32
 
 #include <conio.h>
@@ -138,7 +143,7 @@ void Sleep(long x);
 #endif
 #endif
 
-using namespace std;
+
 
 typedef unsigned long long U64;
 typedef signed long long S64;
@@ -453,6 +458,7 @@ public:
     void replace(int i, int16_t b) { if (!i) v = ((int32_t)((uint32_t)GETMGVAL(v) << 16) + b); else v = ((int32_t)((uint32_t)b << 16) + GETEGVAL(v)); }
     void replace(int16_t b) { v = b; }
 };
+
 
 
 #define VALUE(m, e) eval(m, e)
@@ -1858,8 +1864,9 @@ public:
 //
 // engine stuff
 //
-extern void uciSetLogFile();
-extern void engineHeader();
+void uciSetLogFile();
+void engineHeader();
+
 class GuiCommunication {
 private:
     ostream* myos;
@@ -2330,7 +2337,7 @@ template <RootsearchType RT> void mainSearch(searchthread* thr);
 //
 extern int TBlargest; // 5 if 5-piece tables, 6 if 6-piece tables were found.
 
-void init_tablebases(char *path);
+//void init_tablebases(char *path);
 
 #ifdef TBDEBUG
 #define TBDEBUGDO(l,s) if ((l) <= TBDEBUG) {s}
@@ -2627,3 +2634,9 @@ namespace Simd {
 
 #endif
 }
+
+
+} // namespace rubichess
+
+
+void init_tablebases(char *path);

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -18,6 +18,10 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
+namespace rubichess {
+
 U64 knight_attacks[64];
 U64 king_attacks[64];
 U64 pawn_moves_to[64][2];          // bitboard of target square a pawn on index squares moves to
@@ -40,6 +44,7 @@ U64 lineMask[64][64];
 int squareDistance[64][64];  // decreased by 1 for directly indexing evaluation arrays
 alignas(64) int psqtable[14][64];
 
+}
 
 bool chessposition::w2m()
 {
@@ -635,6 +640,8 @@ void chessposition::pvdebugout()
 
 #endif
 
+namespace rubichess {
+
 // shameless copy from https://www.chessprogramming.org/Magic_Bitboards
 alignas(64) U64 mBishopAttacks[64][1 << BISHOPINDEXBITS];
 alignas(64) U64 mRookAttacks[64][1 << ROOKINDEXBITS];
@@ -874,6 +881,9 @@ void initBitmaphelper()
         }
     }
 }
+
+} // namespace rubichess
+
 
 
 void chessposition::BitboardSet(int index, PieceCode p)
@@ -1131,6 +1141,7 @@ int chessposition::getBestPossibleCapture()
 }
 
 
+namespace rubichess {
 
 // Some global objects
 alignas(64) compilerinfo cinfo;
@@ -1155,3 +1166,5 @@ template void chessposition::updatePins<WHITE>();
 template void chessposition::updatePins<BLACK>();
 template void chessposition::updateThreats<WHITE>();
 template void chessposition::updateThreats<BLACK>();
+
+}

--- a/src/book.cpp
+++ b/src/book.cpp
@@ -18,6 +18,8 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
 //
 // Support for polyglot opening books
 // http://hgm.nubati.net/book_format.html
@@ -462,6 +464,11 @@ uint32_t polybook::GetMove(chessposition* p)
     return p->shortMove2FullMove(shortmove);
 }
 
+namespace rubichess {
+
 // global object
 polybook pbook;
+
+}
+
 

--- a/src/cputest.cpp
+++ b/src/cputest.cpp
@@ -18,6 +18,8 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
 #ifdef CPUTEST
 
 #if defined(_M_X64) || defined(__amd64)

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -18,6 +18,10 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
+namespace rubichess {
+
 void engineHeader()
 {
     guiCom << "========================================================================================\n";
@@ -29,6 +33,7 @@ void engineHeader()
     guiCom << "CPU-Features of binary: " + cinfo.PrintCpuFeatures(cinfo.binarySupports) + "\n";
     guiCom << "========================================================================================\n";
 }
+
 
 
 //
@@ -159,6 +164,9 @@ static void uciSetContempt()
         en.ResultingContempt = newResultingContempt;
     }
 }
+
+} // namespace rubichess
+
 
 
 engine::engine(compilerinfo *c)

--- a/src/eval.cpp
+++ b/src/eval.cpp
@@ -18,6 +18,10 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
+namespace rubichess {
+
 // Evaluation stuff
 
 // static values for the search/pruning/material stuff
@@ -38,6 +42,9 @@ void initPsqtable()
         }
     }
 }
+
+} // namespace rubichess
+
 
 
 #ifdef EVALTUNE
@@ -99,6 +106,8 @@ static void registertuner(chessposition* pos, eval* e, string name, int index1, 
     registerforoptions(e, name, index1, bound1, index2, bound2);
 #endif
 }
+
+namespace rubichess {
 
 const int maxmobility[4] = { 9, 14, 15, 28 }; // indexed by piece - 2
 
@@ -222,6 +231,9 @@ void registerallevals(chessposition *pos)
         for (j = 0; j < 64; j++)
             registertuner(pos, &eps.ePsqt[i][j], "ePsqt", j, 64, i, 7, tuneIt && (i >= KNIGHT || (i == PAWN && j >= 8 && j < 56)));
 }
+
+} // namespace rubichess
+
 #endif
 
 struct traceeval {
@@ -261,31 +273,33 @@ static string splitvaluestring(int v[])
     return ss.str();
 }
 
+namespace rubichess {
+
 void traceEvalOut()
 {
     stringstream ss;
     ss << std::showpoint << std::noshowpos << std::fixed << std::setprecision(2)
-        << "              |    White    |    Black    |    Total   \n"
-        << "              |   MG    EG  |   MG    EG  |   MG    EG \n"
-        << " -------------+-------------+-------------+------------\n"
-        << "     Material | " << splitvaluestring(te.material)
-        << "       Minors | " << splitvaluestring(te.minors)
-        << "        Rooks | " << splitvaluestring(te.rooks)
-        << "        Pawns | " << splitvaluestring(te.pawns)
-        << "      Passers | " << splitvaluestring(te.ppawns)
-        << "     Mobility | " << splitvaluestring(te.mobility)
-        << "      Threats | " << splitvaluestring(te.threats)
-        << " King attacks | " << splitvaluestring(te.kingattackpower)
-        << "   Complexity | " << splitvaluestring(te.complexity)
-        << " -------------+-------------+-------------+------------\n"
-        << "        Total |  Ph=" << setw(3) << te.ph << "/256 |  Sc=" << setw(3) << te.sc << "/128 | " << splitvaluestring(te.total)
-        << " => " << cp(TAPEREDANDSCALEDEVAL(te.total, te.ph, te.sc)) << "\n"
-        << "        Tempo | " << splitvaluestring(te.tempo)
-        << "      Endgame | " << setw(5) << cp(te.endgame) << "\n"
-        << "    Resulting | " << setw(5) << cp(te.score) << "\n";
-
+    << "              |    White    |    Black    |    Total   \n"
+    << "              |   MG    EG  |   MG    EG  |   MG    EG \n"
+    << " -------------+-------------+-------------+------------\n"
+    << "     Material | " << splitvaluestring(te.material)
+    << "       Minors | " << splitvaluestring(te.minors)
+    << "        Rooks | " << splitvaluestring(te.rooks)
+    << "        Pawns | " << splitvaluestring(te.pawns)
+    << "      Passers | " << splitvaluestring(te.ppawns)
+    << "     Mobility | " << splitvaluestring(te.mobility)
+    << "      Threats | " << splitvaluestring(te.threats)
+    << " King attacks | " << splitvaluestring(te.kingattackpower)
+    << "   Complexity | " << splitvaluestring(te.complexity)
+    << " -------------+-------------+-------------+------------\n"
+    << "        Total |  Ph=" << setw(3) << te.ph << "/256 |  Sc=" << setw(3) << te.sc << "/128 | " << splitvaluestring(te.total)
+    << " => " << cp(TAPEREDANDSCALEDEVAL(te.total, te.ph, te.sc)) << "\n"
+    << "        Tempo | " << splitvaluestring(te.tempo)
+    << "      Endgame | " << setw(5) << cp(te.endgame) << "\n"
+    << "    Resulting | " << setw(5) << cp(te.score) << "\n";
+    
     cout << ss.str();
-
+    
 }
 
 #if 0  // this could be useful if endgames are preregistered
@@ -312,13 +326,15 @@ inline int KBNvK(chessposition *p)
     int bishopcol = p->piece00[WBISHOP + strongside] & WHITEBB ? WHITE : BLACK;
     int c1 = bishopcol == WHITE ? 7 : 0;  // lower corner of same color as bishop
     int c2 = bishopcol == WHITE ? 56 : 63;  // upper corner of same color as bishop
-
+    
     const double pw = 0.7;
     int kwcornerdistance = (int)(10.0 * min(pow(abs(FILE(c1) - FILE(kw)), pw) + pow(abs(RANK(c1) - RANK(kw)), pw),
-        pow(abs(FILE(c2) - FILE(kw)), pw) + pow(abs(RANK(c2) - RANK(kw)), pw)));
-
+                                            pow(abs(FILE(c2) - FILE(kw)), pw) + pow(abs(RANK(c2) - RANK(kw)), pw)));
+    
     return (1000 - kwcornerdistance * 10 - squareDistance[ks][kw] - p->testRepetition() * 50 - p->halfmovescounter) * S2MSIGN(strongside);
 }
+
+} // namespace rubichess
 
 
 // get psqt for eval tracing and tuning

--- a/src/learn.cpp
+++ b/src/learn.cpp
@@ -22,6 +22,8 @@
 #include <atomic>
 #include <mutex>
 
+using namespace rubichess;
+
 /*
     Summary about different 16bit move encoding:
     Rubi:

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -18,6 +18,7 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
 
 void generateEpd(string egn)
 {

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -18,6 +18,8 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
 chessmove::chessmove(int from, int to, PieceCode promote, PieceCode capture, int ept, PieceCode piece)
 {
     code = (piece << 28) | (ept << 20) | (capture << 16) | (promote << 12) | (from << 6) | to;

--- a/src/nnue.cpp
+++ b/src/nnue.cpp
@@ -24,6 +24,8 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
 //
 // Some NNUE related constants and types
 //
@@ -64,6 +66,7 @@ static constexpr int KingBucket[64] = {
 };
 
 
+namespace rubichess {
 //
 // Global objects
 //
@@ -71,6 +74,7 @@ NnueType NnueReady = NnueDisabled;
 eval NnueValueScale = 64;
 NnueArchitecture* NnueCurrentArch;
 
+}
 
 // The network architecture V1
 class NnueArchitectureV1 : public NnueArchitecture {
@@ -1026,6 +1030,9 @@ int chessposition::NnueGetEval()
     return NnueCurrentArch->GetEval(this);
 }
 
+
+
+namespace rubichess {
 
 //
 // FeatureTransformer
@@ -2076,6 +2083,12 @@ void NnueRegisterEvals()
     en.ucioptions.Register(&NnueValueScale, "NnueValueScale", ucinnuebias, to_string(NnueValueScale), INT_MIN, INT_MAX, nullptr);
 }
 #endif
+
+
+} // namespace rubichess
+
+
+
 
 
 bool NnueNetsource::open()

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -18,6 +18,11 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
+namespace rubichess {
+
+
 #ifdef STATISTICS
 statistic statistics;
 #endif
@@ -57,6 +62,7 @@ void searchinit()
     searchtableinit();
 }
 
+} // namespace rubichess
 
 inline bool chessposition::CheckForImmediateStop()
 {
@@ -1241,6 +1247,7 @@ int chessposition::rootsearch(int alpha, int beta, int *depthptr, int inWindowLa
     return alpha;
 }
 
+namespace rubichess {
 
 inline bool uciScoreOutputNeeded(int inWindow, U64 thinktime)
 {
@@ -1662,3 +1669,6 @@ template int chessposition::alphabeta<NoPrune>(int alpha, int beta, int depth, b
 template int chessposition::rootsearch<MultiPVSearch>(int, int, int*, int, int);
 template void mainSearch<SinglePVSearch>(searchthread*);
 template void mainSearch<MultiPVSearch>(searchthread*);
+
+
+} // namespace rubichess

--- a/src/tbcore.h
+++ b/src/tbcore.h
@@ -50,6 +50,9 @@
 
 #define TBHASHBITS 12
 
+namespace rubichess {
+
+
 struct TBHashEntry;
 
 #ifdef DECOMP64
@@ -162,6 +165,9 @@ struct DTZTableEntry {
   uint64_t key2;
   struct TBEntry *entry;
 };
+
+
+} // namespace rubichess
 
 #endif
 

--- a/src/tbprobe.cpp
+++ b/src/tbprobe.cpp
@@ -32,9 +32,15 @@
 #include "RubiChess.h"
 #include "tbcore.h"
 
+using namespace rubichess;
+
 #define SYZYGY2RUBI_PT(x) ((((x) & 0x7) << 1) | (((x) & 0x8) >> 3))
 
+namespace rubichess {
+
 int TBlargest = 0;
+
+} // namespace rubichess
 
 #include "tbcore.c"
 

--- a/src/texel.cpp
+++ b/src/texel.cpp
@@ -21,6 +21,8 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
 #ifdef EVALTUNE
 
 alignas(64) evalparamset epsdefault;

--- a/src/transposition.cpp
+++ b/src/transposition.cpp
@@ -23,6 +23,7 @@ static const size_t HashAlignBytes = 2ull << 20;
 #include <sys/mman.h> // madvise
 #endif
 
+using namespace rubichess;
 
 zobrist::zobrist()
 {
@@ -377,5 +378,7 @@ bool  Materialhash::probeHash(U64 hash, Materialhashentry **entry)
     return false;
 }
 
-
+namespace rubichess {
 transposition tp;
+}
+

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -18,6 +18,9 @@
 
 #include "RubiChess.h"
 
+using namespace rubichess;
+
+namespace rubichess {
 
 /* A small noncryptographic PRNG                       */
 /* http://www.burtleburtle.net/bob/rand/smallprng.html */
@@ -417,6 +420,9 @@ string moveToString(uint32_t mc)
     return s;
 }
 
+} // namespace rubichess
+
+
 
 string chessposition::AlgebraicFromShort(string s)
 {
@@ -639,6 +645,9 @@ void compilerinfo::GetSystemInfo()
 #endif
 
 
+namespace rubichess {
+
+
 #ifdef _WIN32
 #include <process.h>
 int compilerinfo::GetProcessId()
@@ -668,7 +677,7 @@ void* my_large_malloc(size_t s)
 {
     void* mem = nullptr;
     bool allowlp = en.allowlargepages;
-
+    
     if (allowlp && UseLargePages < 0)
     {
         // Check and preparations for use of large pages... only once
@@ -676,7 +685,7 @@ void* my_large_malloc(size_t s)
         LUID luid{ };
         largePageSize = GetLargePageMinimum();
         UseLargePages = (bool)largePageSize;
-
+        
         // Activate SeLockMemoryPrivilege
         UseLargePages = UseLargePages && OpenProcessToken(GetCurrentProcess(), TOKEN_ADJUST_PRIVILEGES | TOKEN_QUERY, &hProcessToken);
         UseLargePages = UseLargePages && LookupPrivilegeValue(NULL, SE_LOCK_MEMORY_NAME, &luid);
@@ -685,41 +694,41 @@ void* my_large_malloc(size_t s)
             TOKEN_PRIVILEGES  tokenPriv{ };
             TOKEN_PRIVILEGES prevTp{ };
             DWORD prevTpLen = 0;
-
+            
             tokenPriv.PrivilegeCount = 1;
             tokenPriv.Privileges[0].Luid = luid;
             tokenPriv.Privileges[0].Attributes = SE_PRIVILEGE_ENABLED;
-
+            
             // Try to enable SeLockMemoryPrivilege. Note that even if AdjustTokenPrivileges() succeeds,
             // we still need to query GetLastError() to ensure that the privileges were actually obtained.
             UseLargePages = UseLargePages && AdjustTokenPrivileges(hProcessToken, FALSE, &tokenPriv, sizeof(TOKEN_PRIVILEGES), &prevTp, &prevTpLen);
             UseLargePages = UseLargePages && (GetLastError() == ERROR_SUCCESS);
             CloseHandle(hProcessToken);
         }
-
+        
         guiCom << (UseLargePages ? "info string Allocation of memory uses large pages.\n" : "info string Allocation of memory: Large pages not available.\n");
     }
-
+    
     if (allowlp && UseLargePages)
     {
         // Round up size to full pages and allocate
         s = (s + largePageSize - 1) & ~size_t(largePageSize - 1);
         mem = VirtualAlloc(
-            NULL, s, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES, PAGE_READWRITE);
-
+                           NULL, s, MEM_RESERVE | MEM_COMMIT | MEM_LARGE_PAGES, PAGE_READWRITE);
+        
         if (!mem)
         {
             UseLargePages = -1;
             guiCom << "info string Allocation of memory: Large pages not available for this size. Disabled for now.\n";
         }
     }
-
+    
     if (!mem)
         mem = _aligned_malloc(s, 64);
-
+    
     if (!mem)
         cerr << "Cannot allocate memory (" << s << " bytes)\n";
-
+    
     return mem;
 }
 
@@ -728,7 +737,7 @@ void my_large_free(void* m)
 {
     if (!m)
         return;
-
+    
     if (en.allowlargepages && UseLargePages > 0)
         VirtualFree(m, 0, MEM_RELEASE);
     else
@@ -746,6 +755,8 @@ int compilerinfo::GetProcessId()
 {
     return getpid();
 }
+
+
 
 U64 getTime()
 {
@@ -776,6 +787,7 @@ string CurrentWorkingDir()
     return working_directory + kPathSeparator;
 }
 
+} // namespace rubichess
 
 
 #ifdef STATISTICS


### PR DESCRIPTION
When embedding the chess engines into a project to work with other chess engines and or chess GUI code, a namespace can help to avoid conflicts between them because of having similar names for classes, functions and variants.