### PR TITLE
Go back three moves in continuation history when evaluating quiet moves.

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1698,7 +1698,7 @@ public:
     int16_t counterhistory[14][64][14 * 64];
     int16_t tacticalhst[7][64][6];
     uint32_t countermove[14][64];
-    int16_t* prerootconthistptr[4];
+    int16_t* prerootconthistptr[6];
     int16_t* conthistptr[MAXDEPTH];
     int he_threshold;
     U64 he_yes;

--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -320,7 +320,7 @@ void chessposition::resetStats()
     memset(counterhistory, 0, sizeof(chessposition::counterhistory));
     memset(countermove, 0, sizeof(chessposition::countermove));
     memset(conthistptr, 0, sizeof(chessposition::conthistptr));
-    for (int i = 0; i < 4; i++)
+    for (int i = 0; i < 6; i++)
         prerootconthistptr[i] = counterhistory[0][0];
     he_yes = 0ULL;
     he_all = 0ULL;

--- a/src/move.cpp
+++ b/src/move.cpp
@@ -197,7 +197,7 @@ void chessposition::evaluateMoves(chessmovelist *ml)
             int to = GETCORRECTTO(mc);
             ml->move[i].value = history[piece & S2MMASK][threatSquare][GETFROM(mc)][to];
             int pieceTo = piece * 64 + to;
-            ml->move[i].value += (conthistptr[ply - 1][pieceTo] + conthistptr[ply - 2][pieceTo] + conthistptr[ply - 4][pieceTo]);
+            ml->move[i].value += (conthistptr[ply - 1][pieceTo] + conthistptr[ply - 2][pieceTo] + (conthistptr[ply - 4][pieceTo] + conthistptr[ply - 6][pieceTo]) / 2);
         }
         if (GETPROMOTION(mc))
             ml->move[i].value += mvv[GETPROMOTION(mc) >> 1] - mvv[PAWN];


### PR DESCRIPTION
Bench 3161490