### PR TITLE
Tweak 1

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -810,7 +810,8 @@ int chessposition::alphabeta(int alpha, int beta, int depth, bool cutnode)
             reduction -= (CurrentMoveNum[ply - 1] >= sps.lmropponentmovecount);
 
             // less reduction if next ply had few fail highs
-            reduction -= (failhighcount[ply] < 4);
+            if (failhighcount[ply] < 4)
+                reduction -= (5 - failhighcount[ply]) / 2;
 
             STATISTICSINC(red_pi[positionImproved]);
             STATISTICSADD(red_lmr[positionImproved], reductiontable[positionImproved][depth][min(63, legalMoves + 1)]);


### PR DESCRIPTION
```
STC:
Elo   | 2.15 +- 2.22 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 44684 W: 10788 L: 10511 D: 23385
Penta | [155, 5201, 11386, 5412, 188]
http://chess.grantnet.us/test/34766/

LTC:
Elo   | 2.66 +- 2.69 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 29756 W: 7063 L: 6835 D: 15858
Penta | [36, 3236, 8115, 3446, 45]
http://chess.grantnet.us/test/34770/
```
Bench: 2987595