### PR TITLE
Limitcheckextension

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1522,7 +1522,7 @@ extern int squareDistance[64][64];
 struct chessmovestack
 {
     int state;
-    uint8_t doubleextensions;
+    uint8_t extensionlimit;
     uint8_t ept;
     uint8_t kingpos[2];
     U64 hash;
@@ -1661,7 +1661,7 @@ public:
 
     // The following block is mapped/copied to the movestack, so its important to keep the order
     int state;
-    uint8_t doubleextensions;
+    uint8_t extensionguard;     // lower 4 bits for double extensions, higher 4 bits for check extensions
     uint8_t ept;
     uint8_t kingpos[2];
     U64 hash;

--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -2328,6 +2328,10 @@ struct searchparamset {
     searchparam SP(aspincratio, 5, 1, 10);
     searchparam SP(aspincbase, 1, 1, 10);
     searchparam SP(aspinitialdelta, 11, 1, 20);
+    // Extension guard
+    searchparam SP(extguarddoubleext, 6, 1, 15);
+    searchparam SP(extguardcheckext, 6, 1, 15);
+
 };
 
 extern SPSCONST searchparamset sps;

--- a/src/board.cpp
+++ b/src/board.cpp
@@ -273,7 +273,7 @@ int chessposition::getFromFen(const char* sFen)
     lastnullmove = -1;
     ply = 0;
     piececount = POPCOUNT(occupied00[WHITE] | occupied00[BLACK]);
-    doubleextensions = 0;
+    extensionguard = 0;
     return 0;
 }
 

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -496,8 +496,9 @@ int chessposition::alphabeta(int alpha, int beta, int depth, bool cutnode)
     }
 
     // Check extension
-    if (isCheckbb)
+    if (isCheckbb && extensionguard < 6 * 16)
     {
+        extensionguard += 16;
         extendall = 1;
     }
     else {
@@ -742,8 +743,8 @@ int chessposition::alphabeta(int alpha, int beta, int depth, bool cutnode)
                     // Move is singular
                     STATISTICSINC(extend_singular);
 
-                    if (!PVNode  && redScore < sBeta - sps.singularmarginfor2 && doubleextensions <= 6) {
-                        doubleextensions++;
+                    if (!PVNode  && redScore < sBeta - sps.singularmarginfor2 && (extensionguard & 0xf) <= 6) {
+                        extensionguard++;
                         extendMove = 2;
                     }
                     else {

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -496,7 +496,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth, bool cutnode)
     }
 
     // Check extension
-    if (isCheckbb && extensionguard < 6 * 16)
+    if (isCheckbb && extensionguard < sps.extguardcheckext * 16)
     {
         extensionguard += 16;
         extendall = 1;
@@ -743,7 +743,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth, bool cutnode)
                     // Move is singular
                     STATISTICSINC(extend_singular);
 
-                    if (!PVNode  && redScore < sBeta - sps.singularmarginfor2 && (extensionguard & 0xf) <= 6) {
+                    if (!PVNode  && redScore < sBeta - sps.singularmarginfor2 && (extensionguard & 0xf) <= sps.extguarddoubleext) {
                         extensionguard++;
                         extendMove = 2;
                     }


### PR DESCRIPTION
STC:
Elo   | 1.32 +- 1.45 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 108252 W: 26847 L: 26437 D: 54968
Penta | [395, 12072, 28822, 12402, 435]

LTC:
Elo   | 2.80 +- 2.86 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 27300 W: 6683 L: 6463 D: 14154
Penta | [18, 2937, 7533, 3131, 31]
