### PR TITLE
Don't return with TT move and score in root.

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -1820,7 +1820,7 @@ public:
     void getScaling(Materialhashentry *mhentry);
     int getComplexity(int eval, pawnhashentry *phentry, Materialhashentry *mhentry);
 
-    template <RootsearchType RT> int rootsearch(int alpha, int beta, int *depth, int inWindowLast, int maxmoveindex = 0);
+    template <RootsearchType RT> int rootsearch(int alpha, int beta, int depth, int inWindowLast, int maxmoveindex = 0);
     template <PruneType Pt> int alphabeta(int alpha, int beta, int depth, bool cutnode);
     template <PruneType Pt> int getQuiescence(int alpha, int beta, int depth);
     void updateHistory(uint32_t code, int value);

--- a/src/learn.cpp
+++ b/src/learn.cpp
@@ -1155,7 +1155,7 @@ SKIP_SAVE:
                         pos->getRootMoves();
                         int cur_multi_pv = min(pos->rootmovelist.length, (ply < random_opening_ply ? 8 : random_multi_pv));
                         int cur_multi_pv_diff = (ply < random_opening_ply ? 100 : random_multi_pv_diff);
-                        pos->rootsearch<MultiPVSearch>(SCOREBLACKWINS, SCOREWHITEWINS, &random_multi_pv_depth, 1, cur_multi_pv);
+                        pos->rootsearch<MultiPVSearch>(SCOREBLACKWINS, SCOREWHITEWINS, random_multi_pv_depth, 1, cur_multi_pv);
                         int s = min(pos->rootmovelist.length, cur_multi_pv);
                         // Exclude moves with score outside of allowed margin
                         while (cur_multi_pv_diff && pos->bestmovescore[0] > pos->bestmovescore[s - 1] + cur_multi_pv_diff)

--- a/src/search.cpp
+++ b/src/search.cpp
@@ -974,9 +974,8 @@ int chessposition::alphabeta(int alpha, int beta, int depth, bool cutnode)
 
 
 template <RootsearchType RT>
-int chessposition::rootsearch(int alpha, int beta, int *depthptr, int inWindowLast, int maxmoveindex)
+int chessposition::rootsearch(int alpha, int beta, int depth, int inWindowLast, int maxmoveindex)
 {
-    int depth = *depthptr;
     int bestscore = NOSCORE;
     int eval_type = HASHALPHA;
     chessmove *m;
@@ -1026,13 +1025,6 @@ int chessposition::rootsearch(int alpha, int beta, int *depthptr, int inWindowLa
                 pondermove = 0;
             }
             updatePvTable(fullhashmove, false);
-            if (score > alpha) {
-                bestmovescore[0] = score;
-                SDEBUGDO(isDebugPv, pvabortscore[0] = score; if (debugMove == hashmovecode) pvaborttype[0] = PVA_FROMTT; else pvaborttype[0] = PVA_DIFFERENTFROMTT; );
-                SDEBUGDO(isDebugPv, pvadditionalinfo[0] = "PV = " + getPv(pvtable[0]) + "  " + tp.debugGetPv(hash, 0); );
-                *depthptr = newDepth;
-                return score;
-            }
         }
     }
 
@@ -1366,7 +1358,7 @@ void mainSearch(searchthread *thr)
         }
         else
         {
-            score = pos->rootsearch<RT>(alpha, beta, &thr->depth, inWindow);
+            score = pos->rootsearch<RT>(alpha, beta, thr->depth, inWindow);
 #ifdef TDEBUG
             if (en.stopLevel == ENGINESTOPIMMEDIATELY && isMainThread)
             {
@@ -1702,7 +1694,7 @@ void mainSearch(searchthread *thr)
 // Explicit template instantiation
 // This avoids putting these definitions in header file
 template int chessposition::alphabeta<NoPrune>(int alpha, int beta, int depth, bool cutnode);
-template int chessposition::rootsearch<MultiPVSearch>(int, int, int*, int, int);
+template int chessposition::rootsearch<MultiPVSearch>(int, int, int, int, int);
 template void mainSearch<SinglePVSearch>(searchthread*);
 template void mainSearch<MultiPVSearch>(searchthread*);
 


### PR DESCRIPTION
This improves forward/backward ananysis and should "fix" bad time management at tournaments with big machines and long TC like TCEC where Rubi gets stuck on depth n+1 after reading depth n from TT.
```
Elo   | 1.42 +- 3.17 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.95 (-2.94, 2.94) [-3.00, 1.00]
Games | N: 22258 W: 5445 L: 5354 D: 11459
Penta | [24, 2351, 6287, 2444, 23]
http://chess.grantnet.us/test/36736/
```
Bench: 5450474