### PR TITLE
New network trained for 400 epochs from scratch on 55GB binpack data,…

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -17,8 +17,8 @@
 
 #pragma once
 
-#define VERNUMLEGACY 2023
-#define NNUEDEFAULT nn-c257b2ebf1-20230812.nnue
+#define VERNUMLEGACY 2024
+#define NNUEDEFAULT nn-bc638d5ec9-20240730.nnue
 
 // enable this switch for faster SSE2 code using 16bit integers
 #define FASTSSE2


### PR DESCRIPTION
… replaced oldest 13GB of data with 26GB of new data compared to last training.

SPRT[0,3] tests leading to this network:
Epoch sha256 vs.     STC     LTC
319     71363 master  + 9.10  + 3.04
339     4797b 71363   + 4.93  + 3.06
399     bc638 4797b   + 2.49  + 4.55
Bench: 6203151