### PR TITLE
Store native depth in TT.

### DIFF
--- a/src/search.cpp
+++ b/src/search.cpp
@@ -946,7 +946,7 @@ int chessposition::alphabeta(int alpha, int beta, int depth, bool cutnode)
                         if (!ISCAPTURE(bestcode) && !isCheckbb && !(bestscore < staticeval))
                             updateCorrectionHst(bestscore - staticeval, depth);
 
-                        tp.addHash(tte, newhash, FIXMATESCOREADD(score, ply), rawstaticeval, HASHBETA, effectiveDepth, (uint16_t)bestcode);
+                        tp.addHash(tte, newhash, FIXMATESCOREADD(score, ply), rawstaticeval, HASHBETA, depth, (uint16_t)bestcode);
                     }
 
                     SDEBUGDO(isDebugPv, pvaborttype[ply] = isDebugMove ? PVA_BETACUT : debugMovePlayed ? PVA_NOTBESTMOVE : PVA_OMITTED;);
@@ -1268,7 +1268,7 @@ int chessposition::rootsearch(int alpha, int beta, int depth, int inWindowLast, 
                         updateTacticalHst(tacticalMoves[0][t], -(depth * depth));
 
                 }
-                tp.addHash(tte, hash, beta, staticeval, HASHBETA, effectiveDepth, (uint16_t)m->code);
+                tp.addHash(tte, hash, beta, staticeval, HASHBETA, depth, (uint16_t)m->code);
                 SDEBUGDO(isDebugPv, pvaborttype[0] = isDebugMove ? PVA_BETACUT : debugMovePlayed ? PVA_NOTBESTMOVE : PVA_OMITTED;);
                 SDEBUGDO(isDebugPv, tp.debugSetPv(hash, movesOnStack() + " effectiveDepth=" + to_string(effectiveDepth)););
                 return beta;   // fail hard beta-cutoff


### PR DESCRIPTION
STC:
Elo   | 3.20 +- 2.99 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=8MB
LLR   | 2.95 (-2.94, 2.94) [0.00, 3.00]
Games | N: 25602 W: 6453 L: 6217 D: 12932
Penta | [96, 2948, 6507, 3124, 126]

LTC:
Elo   | 8.36 +- 5.45 (95%)
SPRT  | 60.0+0.60s Threads=1 Hash=64MB
LLR   | 2.97 (-2.94, 2.94) [0.00, 3.00]
Games | N: 7444 W: 1868 L: 1689 D: 3887
Penta | [2, 742, 2059, 913, 6]

Bench: 5134491