### PR TITLE
Fix missing ) error in line 178

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -175,7 +175,7 @@ endif
 CPUFLAGS = "$(shell ./$(CPUTEST)$(EXEEXT))"
 endif
 
-HASLIBNUMA = $(shell echo '#include "numa.h"' | $(CXX) -E - > /dev/null 2>&1 && echo 'yes')
+HASLIBNUMA = $(shell echo '\#include "numa.h"' | $(CXX) -E - >/dev/null 2>&1 && echo 'yes')
 ifeq ($(HASLIBNUMA),yes)
 CXXFLAGS += -DUSE_LIBNUMA
 LDFLAGS += -lnuma


### PR DESCRIPTION
Fixes the following error message on MacOs:

Makefile:178: *** unterminated call to function `shell': missing `)'.  Stop.