### PR TITLE
bestmovescore also needs early reset to avoid wrong thread voting.

### DIFF
--- a/src/engine.cpp
+++ b/src/engine.cpp
@@ -895,7 +895,6 @@ void prepareSearch(chessposition* pos, chessposition* rootpos)
     // cout << offsetof(chessposition, history) << "\n";
     memcpy((void*)pos, rootpos, offsetof(chessposition, history));
     // reset of several variables that are not clean in rootpos
-    pos->bestmovescore[0] = NOSCORE;
     pos->bestmove = 0;
     pos->pondermove = 0;
     pos->nullmoveply = 0;
@@ -969,7 +968,8 @@ void engine::searchStart()
         pos->threadindex = tnum;   // signal that the thread is (will be) alive
         pos->nodes = 0;
         pos->tbhits = 0;
-        sthread[tnum].lastCompleteDepth = 0;    // needs early reset to avoid thread voting with threads not started yet
+        pos->bestmovescore[0] = NOSCORE;
+        sthread[tnum].lastCompleteDepth = 0;    // these two need early reset to avoid thread voting with threads not started yet
     }
 
     for (int tnum = 0; tnum < Threads; tnum++)

--- a/src/tbprobe.cpp
+++ b/src/tbprobe.cpp
@@ -701,9 +701,10 @@ int chessposition::root_probe_dtz()
         TBDEBUGDO(1, printf("info string root_probe_dtz (ply=%d) Tested  move %s... value=%d\n", ply, m->toString().c_str(), v);)
         unplayMove<false>(m->code);
         if (!success)
-            return 0;
-
-        m->value = v;
+            // probing was not successful, probably a missing TB file, so expect the worst
+            m->value = -1;
+        else
+            m->value = v;
     }
 
     // Obtain 50-move counter for the root position.


### PR DESCRIPTION
Fixes #515 and also improves playing with incomplete TB sets.