### PR TITLE
New network.

### DIFF
--- a/src/RubiChess.h
+++ b/src/RubiChess.h
@@ -18,7 +18,7 @@
 #pragma once
 
 #define VERNUMLEGACY 2026
-#define NNUEDEFAULT nn-6b25a84c8a-20260809.nnue
+#define NNUEDEFAULT nn-da9c99e92a-20260819.nnue
 
 // Enable to get statistical values about various search features
 //#define STATISTICS


### PR DESCRIPTION
Results of RubiChess-da9c9 vs RubiChess-ms (60+0.6, 1t, 64MB, UHO_4060_v4.epd):
Elo: 9.64 +/- 4.36, nElo: 19.42 +/- 8.78
LOS: 100.00 %, DrawRatio: 51.78 %, PairsRatio: 1.26
Games: 6018, Wins: 1475, Losses: 1308, Draws: 3235, Points: 3092.5 (51.39 %)
Ptnml(0-2): [8, 633, 1558, 804, 6], WL/DD Ratio: 0.73

Bench: 4271839